### PR TITLE
[src-43] Fix focus indicator on Button component

### DIFF
--- a/components/stour/button/button.tsx
+++ b/components/stour/button/button.tsx
@@ -25,17 +25,18 @@ const SIZE = {
   auto: "h-10 px-4 text-sm",
 };
 const VARIANT = {
-  primary: "!text-gray-600 hover:border-black hover:!text-black ring-gray-200",
+  primary:
+    "!text-gray-600 hover:border-black hover:!text-black focus:ring-blue-100 focus:border-black focus:!text-black",
   secondary:
-    "!text-white border-gray-900 bg-gray-900 hover:!text-gray-900 hover:bg-white ring-gray-200",
+    "!text-white border-gray-900 bg-gray-900 hover:!text-gray-900 hover:bg-white focus:ring-blue-100 focus:!text-gray-900 focus:bg-white",
   brand:
-    "!text-white border-blue-700 bg-blue-700 hover:!text-blue-700 hover:bg-white ring-blue-200",
+    "!text-white border-blue-700 bg-blue-700 hover:!text-blue-700 hover:bg-white focus:ring-blue-100 focus:!text-blue-700 focus:bg-white",
   success:
-    "!text-white border-green-600 bg-green-600 hover:!text-green-700 hover:bg-white ring-green-200",
+    "!text-white border-green-600 bg-green-600 hover:!text-green-700 hover:bg-white focus:ring-blue-100 focus:!text-green-700 focus:bg-white",
   error:
-    "!text-white border-red-600 bg-red-600 hover:!text-red-700 hover:bg-white ring-red-200",
+    "!text-white border-red-600 bg-red-600 hover:!text-red-700 hover:bg-white ring-red-200 focus:ring-red-200 focus:!text-red-700 focus:bg-white",
   warning:
-    "!text-white border-yellow-600 bg-yellow-600 hover:!text-yellow-700 hover:bg-white ring-yellow-200",
+    "!text-white border-yellow-600 bg-yellow-600 hover:!text-yellow-700 hover:bg-white ring-yellow-200 focus:ring-yellow-200 focus:!text-yellow-700 focus:bg-white",
 };
 const disabledClassNames =
   "text-gray-300 bg-gray-100 cursor-not-allowed focus:ring-none hover:text-inherit hover:border-inherit";
@@ -57,10 +58,7 @@ const Button = ({
   const Comp = href ? "a" : as;
   const hasIcon = icon !== null;
   const baseClassNames: string =
-    "rounded transition duration-300 border inline-block border-box" +
-    "focus:ring-2 focus:ring-offset-2 focus:outline-none select-none" +
-    "whitespace-nowrap relative text-center leading-none" +
-    "disabled:hover:!text-inherit disabled:hover:border-inherit";
+    "rounded transition duration-300 border inline-block border-box focus:ring-4 focus:outline-none select-none whitespace-nowrap relative text-center leading-none disabled:hover:!text-inherit disabled:hover:border-inherit";
 
   const classNames: string = cn([
     baseClassNames,


### PR DESCRIPTION
Fixes an issue that I either introduced by mistake reflects a change in the way Tailwind works. The button component _did_ have `outline: none` set, but didn't have a custom replacement, which was really not good. 