### PR TITLE
fix: `useURL` shouldn't be stateful

### DIFF
--- a/apps/web/components/footer/reportABug.tsx
+++ b/apps/web/components/footer/reportABug.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname, useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 
 const useLocale = () => Intl.DateTimeFormat().resolvedOptions().locale;
 
@@ -29,6 +29,9 @@ const useURL = () => {
   return url.toString();
 };
 
+const CLASSES = "transition hover:text-black";
+const TEXT = "Report a bug.";
+
 const ReportABug = () => {
   const locale = useLocale();
   const language = useLanguage();
@@ -45,13 +48,21 @@ const ReportABug = () => {
   const message = encodeURIComponent(stringifiedMessage);
 
   return (
-    <a
-      href={`/bugs?message=${message}`}
-      className="transition hover:text-black"
-      suppressHydrationWarning
+    <Suspense
+      fallback={
+        <a href="/bugs" className={CLASSES}>
+          {TEXT}
+        </a>
+      }
     >
-      Report a bug.
-    </a>
+      <a
+        href={`/bugs?message=${message}`}
+        className={CLASSES}
+        suppressHydrationWarning
+      >
+        {TEXT}
+      </a>
+    </Suspense>
   );
 };
 

--- a/apps/web/components/footer/reportABug.tsx
+++ b/apps/web/components/footer/reportABug.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { usePathname, useSearchParams } from "next/navigation";
-import { Suspense, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 const useLocale = () => Intl.DateTimeFormat().resolvedOptions().locale;
 
@@ -16,21 +15,10 @@ const useLanguage = () => {
 };
 
 const useURL = () => {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
+  if (typeof window === "undefined") return "";
 
-  const origin = window ? window.location.origin : undefined;
-
-  const url = new URL(pathname, origin);
-  searchParams.forEach((value, key) => {
-    url.searchParams.set(key, value);
-  });
-
-  return url.toString();
+  return window.location.href;
 };
-
-const CLASSES = "transition hover:text-black";
-const TEXT = "Report a bug.";
 
 const ReportABug = () => {
   const locale = useLocale();
@@ -48,21 +36,13 @@ const ReportABug = () => {
   const message = encodeURIComponent(stringifiedMessage);
 
   return (
-    <Suspense
-      fallback={
-        <a href="/bugs" className={CLASSES}>
-          {TEXT}
-        </a>
-      }
+    <a
+      href={`/bugs?message=${message}`}
+      className="transition hover:text-black"
+      suppressHydrationWarning
     >
-      <a
-        href={`/bugs?message=${message}`}
-        className={CLASSES}
-        suppressHydrationWarning
-      >
-        {TEXT}
-      </a>
-    </Suspense>
+      Report a bug.
+    </a>
   );
 };
 

--- a/apps/web/components/footer/reportABug.tsx
+++ b/apps/web/components/footer/reportABug.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 
 const useLocale = () => Intl.DateTimeFormat().resolvedOptions().locale;
@@ -15,13 +16,17 @@ const useLanguage = () => {
 };
 
 const useURL = () => {
-  const [url, setURL] = useState<string | undefined>(undefined);
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
 
-  useEffect(() => {
-    setURL(window.location.href);
-  }, []);
+  const origin = window ? window.location.origin : undefined;
 
-  return url;
+  const url = new URL(pathname, origin);
+  searchParams.forEach((value, key) => {
+    url.searchParams.set(key, value);
+  });
+
+  return url.toString();
 };
 
 const ReportABug = () => {


### PR DESCRIPTION
A state variable was added at some point (I think in an attempt to isolate the client-only functionality from the server-side prerendering, but it had the unintended effect of persisting earlier URL state).