### PR TITLE
feat: add rate limiting to API routes

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -4,15 +4,8 @@ This is the latest iteration of Sudbury Rowing Club’s website.
 
 - a data source/CMS: [Sanity.io](https://github.com/sanity-io/sanity)
 - a frontend framework: [Next.js](https://github.com/vercel/next.js)
+- some headless component primitives: [Radix UI](https://github.com/radix-ui/radix-ui)
 - a utility-first CSS framework: [Tailwind CSS](https://github.com/tailwindlabs/tailwindcss)
-
-### It also borrows:
-
-- [bar-of-progress](https://github.com/badrap/bar-of-progress), for lightweight loading bars
-- [Headless UI](https://github.com/tailwindlabs/headlessui), for accessible and Tailwind-friendly accordions and popovers
-- [React Final Form](https://github.com/final-form/react-final-form), for lightweight form state management
-- [next-seo](https://github.com/garmeeh/next-seo), to limit the pain caused by social media shares
-- [Pigeon Maps](https://github.com/mariusandra/pigeon-maps), for mapping components
 
 ### For fun, an approximate history of SRC online
 

--- a/apps/web/app/api/bug/BugReportSchema.ts
+++ b/apps/web/app/api/bug/BugReportSchema.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+const BugReportNameSchema = z.string().min(1, "Provide your name");
+const BugReportEmailSchema = z
+  .string()
+  .min(1, "Provide your email")
+  .email("Provide a valid email address");
+const BugReportDescriptionSchema = z
+  .string()
+  .trim()
+  .min(1, "Provide a description");
+const BugReportUserAgentSchema = z.string().min(1, "Provide your user agent");
+const BugReportAdditionalInformationSchema = z.string();
+
+export const BugReportSchema = z.object({
+  name: BugReportNameSchema,
+  email: BugReportEmailSchema,
+  description: BugReportDescriptionSchema,
+  userAgent: BugReportUserAgentSchema,
+  additionalInformation: BugReportAdditionalInformationSchema,
+});
+
+export type BugReport = z.infer<typeof BugReportSchema>;

--- a/apps/web/app/api/events.ics/route.ts
+++ b/apps/web/app/api/events.ics/route.ts
@@ -1,7 +1,8 @@
+import { routeHandlerRatelimiter } from "@/lib/rate-limiter";
 import { serversideFetchCompetitions } from "@sudburyrc/api";
 import IcalBuilder from "@sudburyrc/ical-builder";
 import { kv } from "@vercel/kv";
-import { NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 
 const CACHE_KEY = "events-ics";
 const CACHE_TTL_SECONDS = 60 * 60 * 12; // 12 hours
@@ -32,7 +33,10 @@ const cachedTransformToICS = async () => {
   return icsString;
 };
 
-export const GET = async () => {
+export const GET = async (req: NextRequest) => {
+  const maybeRateLimitedResponse = await routeHandlerRatelimiter(req);
+  if (maybeRateLimitedResponse) return maybeRateLimitedResponse;
+
   try {
     const iCalFeed = await cachedTransformToICS();
 

--- a/apps/web/app/api/notice/route.ts
+++ b/apps/web/app/api/notice/route.ts
@@ -1,5 +1,5 @@
 import { routeHandlerRatelimiter } from "@/lib/rate-limiter";
-import { sanityClient } from "@sudburyrc/api";
+import { ZTypedObject, sanityClient } from "@sudburyrc/api";
 import groq from "groq";
 import { type NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
@@ -9,7 +9,7 @@ export const revalidate = 300;
 const NoticeSchema = z.object({
   display: z.boolean(),
   label: z.string(),
-  text: z.unknown(),
+  text: z.array(ZTypedObject).optional(),
   type: z.enum(["primary", "secondary", "success", "warning", "error"]),
   link: z.string().optional(),
   date: z

--- a/apps/web/app/api/og/route.tsx
+++ b/apps/web/app/api/og/route.tsx
@@ -1,4 +1,5 @@
 import { BASE_URL } from "@/lib/constants";
+import { routeHandlerRatelimiter } from "@/lib/rate-limiter";
 import { Wordmark } from "@sudburyrc/blue";
 import { ImageResponse } from "next/og";
 import type { NextRequest } from "next/server";
@@ -58,6 +59,9 @@ const getFonts = async () =>
   ]);
 
 export const GET = async (request: NextRequest): Promise<ImageResponse> => {
+  const maybeRateLimitedResponse = await routeHandlerRatelimiter(request);
+  if (maybeRateLimitedResponse) return maybeRateLimitedResponse;
+
   const { searchParams } = new URL(request.url);
 
   try {

--- a/apps/web/app/api/pg/route.ts
+++ b/apps/web/app/api/pg/route.ts
@@ -1,10 +1,14 @@
+import { routeHandlerRatelimiter } from "@/lib/rate-limiter";
 import { getWodehouseFullDetails } from "get-wodehouse-name";
-import { NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 
 export const runtime = "edge";
 export const revalidate = 60;
 
-export const GET = () => {
+export const GET = async (req: NextRequest) => {
+  const maybeRateLimitedResponse = await routeHandlerRatelimiter(req);
+  if (maybeRateLimitedResponse) return maybeRateLimitedResponse;
+
   try {
     const status = getWodehouseFullDetails();
 

--- a/apps/web/app/bugs/client-page.tsx
+++ b/apps/web/app/bugs/client-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type BugReport, BugReportSchema } from "@/app/api/bug/route";
+import { type BugReport, BugReportSchema } from "@/app/api/bug/BugReportSchema";
 import Success from "@/components/contact/views/success";
 import Center from "@/components/stour/center";
 import { Button } from "@/components/ui/button";

--- a/apps/web/app/bugs/client-page.tsx
+++ b/apps/web/app/bugs/client-page.tsx
@@ -1,16 +1,18 @@
 "use client";
 
-import type { BugReport } from "@/app/api/bug/route";
-import ErrorView from "@/components/contact/views/error";
+import { type BugReport, BugReportSchema } from "@/app/api/bug/route";
 import Success from "@/components/contact/views/success";
 import Center from "@/components/stour/center";
 import { Button } from "@/components/ui/button";
+import { Error as ErrorComponent } from "@/components/ui/error";
 import { Input } from "@/components/ui/input";
 import { TextArea } from "@/components/ui/textarea";
+import { scrollToSelector } from "@/lib/scrollToSelector";
 import { Obfuscate } from "@south-paw/react-obfuscate-ts";
-import { FORM_ERROR } from "final-form";
+import { useForm } from "@tanstack/react-form";
+import { useMutation } from "@tanstack/react-query";
 import { useQueryState } from "nuqs";
-import { Field, Form } from "react-final-form";
+import { kyInstance } from "../get-query-client";
 
 const getUserAgent = () => {
   if (typeof window === "undefined") return null;
@@ -29,11 +31,33 @@ const formatIfStringIsParseableJSON = (string: string) => {
 export const BugsClientSide = () => {
   const [message] = useQueryState("message");
 
-  const userAgent = getUserAgent() || "Unknown";
+  const { mutateAsync, error } = useMutation({
+    mutationKey: ["bug-report"],
+    mutationFn: (values: BugReport) =>
+      kyInstance.post("/api/bug", { json: values }),
+  });
 
   const additionalInformation = message
     ? formatIfStringIsParseableJSON(message)
-    : undefined;
+    : "";
+
+  const form = useForm({
+    defaultValues: {
+      name: "",
+      email: "",
+      description: "",
+      userAgent: getUserAgent() || "Unknown",
+      additionalInformation,
+    },
+    validators: { onSubmit: BugReportSchema },
+    onSubmit: ({ value }) => mutateAsync(value),
+    canSubmitWhenInvalid: true,
+    onSubmitInvalid: () => scrollToSelector('[aria-invalid="true"]'),
+  });
+
+  if (form.state.isSubmitted) return <Success />;
+
+  const disableFields = form.state.isSubmitting || form.state.isSubmitted;
 
   return (
     <>
@@ -44,162 +68,120 @@ export const BugsClientSide = () => {
         </p>
       </div>
 
-      <Form<BugReport>
-        initialValues={{
-          email: "",
-          description: "",
-          name: "",
-          userAgent,
-          additionalInformation,
+      <form
+        className="grid grid-cols-2 gap-6"
+        onSubmit={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          void form.handleSubmit();
         }}
-        onSubmit={async (values) => {
-          const response = await fetch("/api/bug", {
-            body: JSON.stringify(values),
-            headers: {
-              "Content-Type": "application/json",
-            },
-            method: "POST",
-          });
+      >
+        <form.Field name="name">
+          {({ state, handleBlur, handleChange, name }) => (
+            <Input
+              disabled={disableFields}
+              className="col-span-2 sm:col-span-1"
+              id={name}
+              label="Your name"
+              error={state.meta.errors[0]?.message}
+              type="text"
+              value={state.value}
+              onBlur={handleBlur}
+              onChange={(e) => handleChange(e.target.value)}
+            />
+          )}
+        </form.Field>
 
-          if (response.ok) return Promise.resolve();
+        <form.Field name="email">
+          {({ state, handleBlur, handleChange, name }) => (
+            <Input
+              disabled={disableFields}
+              className="col-span-2 sm:col-span-1"
+              id={name}
+              label="Your email"
+              error={state.meta.errors[0]?.message}
+              inputMode="email"
+              value={state.value}
+              onBlur={handleBlur}
+              onChange={(e) => handleChange(e.target.value)}
+            />
+          )}
+        </form.Field>
 
-          const error = await response.text();
+        <form.Field name="description">
+          {({ state, handleBlur, handleChange, name }) => (
+            <TextArea
+              className="col-span-2"
+              disabled={disableFields}
+              error={state.meta.errors[0]?.message}
+              id={name}
+              minRows={3}
+              label="Description"
+              description="Describe what you were trying to do, what you expected to happen, and what actually happened."
+              value={state.value}
+              onBlur={handleBlur}
+              onChange={(e) => handleChange(e.target.value)}
+            />
+          )}
+        </form.Field>
 
-          return Promise.resolve({
-            [FORM_ERROR]: `${response.status} ${error}`,
-          });
-        }}
-        render={({
-          handleSubmit,
-          submitting,
-          pristine,
-          submitSucceeded,
-          submitFailed,
-          hasValidationErrors,
-          submitErrors,
-        }) => {
-          if (submitFailed)
-            return <ErrorView error={submitErrors?.[FORM_ERROR]} />;
+        <fieldset className="col-span-2 grid gap-4 rounded-sm border bg-gray-50 p-2">
+          <legend className="font-medium text-gray-700 text-xs">
+            Included automatically
+          </legend>
 
-          if (submitSucceeded) return <Success />;
+          <form.Field name="userAgent">
+            {({ state, name }) => (
+              <Input
+                disabled
+                id={name}
+                value={state.value}
+                label="User agent"
+                type="text"
+                className="col-span-2"
+                inputClassName="text-xs p-1.5 font-mono"
+                description="Any time you use the web, your browser identifies itself (not you) to websites using a user agent string. This is included automatically."
+                required={false}
+              />
+            )}
+          </form.Field>
 
-          const disableSubmission =
-            pristine || submitting || submitSucceeded || hasValidationErrors;
-          const disableFields = submitting || submitSucceeded;
+          {form.state.values.additionalInformation && (
+            <form.Field name="additionalInformation">
+              {({ state, handleBlur, handleChange, name }) => (
+                <TextArea
+                  value={state.value}
+                  onBlur={handleBlur}
+                  onChange={(e) => handleChange(e.target.value)}
+                  className="col-span-2"
+                  inputClassName="p-1.5 font-mono text-xs text-gray-600"
+                  disabled={disableFields}
+                  id={name}
+                  required={false}
+                  minRows={3}
+                  label="Additional information"
+                  description="The page you were on when you clicked the “Report a bug” link gave us some additional information. Delete it if you don’t want to include it."
+                />
+              )}
+            </form.Field>
+          )}
+        </fieldset>
 
-          return (
-            <form className="grid grid-cols-2 gap-6" onSubmit={handleSubmit}>
-              <Field name="name">
-                {({ input, meta }) => (
-                  <Input
-                    disabled={disableFields}
-                    className="col-span-2 sm:col-span-1"
-                    id="name"
-                    {...input}
-                    label="Your name"
-                    error={meta.invalid && meta.touched ? meta.error : ""}
-                    type="text"
-                  />
-                )}
-              </Field>
+        {error && <ErrorComponent className="col-span-2" error={error} />}
 
-              <Field name="email">
-                {({ input, meta }) => (
-                  <Input
-                    disabled={disableFields}
-                    className="col-span-2 sm:col-span-1"
-                    id="email"
-                    {...input}
-                    label="Your email"
-                    error={meta.invalid && meta.touched ? meta.error : ""}
-                    type="email"
-                  />
-                )}
-              </Field>
-
-              <Field name="description">
-                {({ input, meta }) => (
-                  <TextArea
-                    {...input}
-                    className="col-span-2"
-                    disabled={disableFields}
-                    error={meta.invalid && meta.touched ? meta.error : ""}
-                    id="message"
-                    minRows={3}
-                    required
-                    label="Description"
-                    description="Describe what you were trying to do, what you expected to happen, and what actually happened."
-                  />
-                )}
-              </Field>
-
-              <fieldset className="col-span-2 grid gap-4 rounded-sm border bg-gray-50 p-2">
-                <legend className="font-medium text-gray-700 text-xs">
-                  Included automatically
-                </legend>
-
-                <Field name="userAgent">
-                  {({ input }) => (
-                    <Input
-                      disabled
-                      id="userAgent"
-                      {...input}
-                      label="User agent"
-                      type="text"
-                      className="col-span-2"
-                      inputClassName="text-xs p-1.5 font-mono"
-                      description="Any time you use the web, your browser identifies itself (not you) to websites using a user agent string. This is included automatically."
-                      required={false}
-                    />
-                  )}
-                </Field>
-
-                {additionalInformation && (
-                  <Field name="additionalInformation">
-                    {({ input }) => (
-                      <TextArea
-                        {...input}
-                        className="col-span-2"
-                        inputClassName="p-1.5 font-mono text-xs text-gray-600"
-                        disabled={disableFields}
-                        id="additionalInformation"
-                        required={false}
-                        minRows={3}
-                        label="Additional information"
-                        description="The page you were on when you clicked the “Report a bug” link gave us some additional information. Delete it if you don’t want to include it."
-                      />
-                    )}
-                  </Field>
-                )}
-              </fieldset>
-
-              <Center className="col-span-2">
-                <Button
-                  id="message"
-                  disabled={disableSubmission}
-                  loading={submitting}
-                  size="lg"
-                  type="submit"
-                  variant="secondary"
-                >
-                  Send
-                </Button>
-              </Center>
-            </form>
-          );
-        }}
-        validate={(values) => {
-          const errors: {
-            name?: string;
-            email?: string;
-            description?: string;
-          } = {};
-          if (!values.name) errors.name = "Required";
-          if (!values.email) errors.email = "Required";
-          if (!values.description) errors.description = "Required";
-          return Object.keys(errors).length ? errors : undefined;
-        }}
-      />
+        <Center className="col-span-2">
+          <Button
+            id="message"
+            disabled={form.state.isSubmitting}
+            loading={form.state.isSubmitting}
+            size="lg"
+            type="submit"
+            variant="secondary"
+          >
+            Send
+          </Button>
+        </Center>
+      </form>
 
       <div className="prose mt-16 text-gray-500 text-sm">
         Alternatively, mail{" "}

--- a/apps/web/app/regatta/draw/page.tsx
+++ b/apps/web/app/regatta/draw/page.tsx
@@ -1,3 +1,4 @@
+import { kyInstance } from "@/app/get-query-client";
 import TextPage from "@/components/layouts/text-page";
 import { Button } from "@/components/ui/button";
 import DateFormatter from "@/components/utils/date-formatter";
@@ -32,10 +33,7 @@ const fetchDraw = async () => {
     firstSaturdayInAugust,
   ).setHours(10);
 
-  const draw = await (async () => {
-    const drawResponse = await fetch(DRAW_URL);
-    return drawResponse.text();
-  })();
+  const draw = await kyInstance.get(DRAW_URL).text();
 
   const thisYearsDrawIsPublished = (() => {
     const drawYear = /20\d\d/.exec(draw)?.[0];

--- a/apps/web/components/banner/index.tsx
+++ b/apps/web/components/banner/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { Notice } from "@/app/api/notice/route";
+import { kyInstance } from "@/app/get-query-client";
 import { useQuery } from "@tanstack/react-query";
 import cn from "clsx";
 import { useEffect, useRef, useState } from "react";
@@ -103,9 +104,10 @@ const ButtonOrAnchor = ({
   })[type];
 
 const Banner = () => {
-  const { data, error } = useQuery<Notice>({
+  const { data, error } = useQuery({
     queryKey: ["notice"],
-    queryFn: () => fetch("/api/notice").then((res) => res.json()),
+    queryFn: ({ signal }) =>
+      kyInstance.get<Notice>("/api/notice", { signal }).json(),
     staleTime: 5 * 60 * 1000,
   });
 

--- a/apps/web/components/contact/contactForm.tsx
+++ b/apps/web/components/contact/contactForm.tsx
@@ -72,7 +72,13 @@ const ContactForm = ({ disabled, contacts, initialValues }: Props) => {
     onSubmitInvalid: () => scrollToSelector('[aria-invalid="true"]'),
   });
 
-  useTestingMode(form);
+  useTestingMode({
+    setValues: (values) => {
+      form.setFieldValue("to", values.to);
+      form.setFieldValue("name", values.name);
+      form.setFieldValue("email", values.email);
+    },
+  });
 
   if (disabled) return <DisabledOverlay form={<div />} />;
   if (form.state.isSubmitted) return <Success />;

--- a/apps/web/components/contact/fields/input.tsx
+++ b/apps/web/components/contact/fields/input.tsx
@@ -21,8 +21,7 @@ type Props = {
 };
 
 /**
- * Provides a simple input field with automatic best-practice labels. Intended for
- * compatibility with the `Field` component from `react-final-form`.
+ * Provides a simple input field with automatic best-practice labels.
  */
 const Input = ({
   input,

--- a/apps/web/components/contact/fields/select.tsx
+++ b/apps/web/components/contact/fields/select.tsx
@@ -19,8 +19,7 @@ type Props = {
 
 /**
  * Provides a simple select field with automatic best-practice label syntax and
- * array-based options. Intended for compatibility with the `Field` component
- * from `react-final-form`.
+ * array-based options.
  */
 const Select = ({
   input,

--- a/apps/web/components/contact/useTestingMode.tsx
+++ b/apps/web/components/contact/useTestingMode.tsx
@@ -3,7 +3,6 @@
 import { browserIndexOfficers } from "@/lib/algolia";
 import { useHotkeys, useOs, useThrottledCallback } from "@mantine/hooks";
 import type { OfficerResponse } from "@sudburyrc/api";
-import type { ReactFormExtendedApi } from "@tanstack/react-form";
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { type ExternalToast, toast } from "sonner";
@@ -14,7 +13,11 @@ const TESTING_MODE_TOAST_OPTIONS = {
   id: "testing-mode",
 } satisfies ExternalToast;
 
-export const useTestingMode = (form: ReactFormExtendedApi<Message>) => {
+export const useTestingMode = ({
+  setValues,
+}: {
+  setValues: (values: Pick<Message, "to" | "name" | "email">) => void;
+}) => {
   const os = useOs();
   const [isEnabled, setIsEnabled] = useState(false);
 
@@ -42,9 +45,7 @@ export const useTestingMode = (form: ReactFormExtendedApi<Message>) => {
       const { firstName, lastName, email } = details;
       const name = `${firstName} ${lastName}`;
 
-      form.setFieldValue("to", webmasterId ?? "");
-      form.setFieldValue("name", name);
-      form.setFieldValue("email", email);
+      setValues({ to: webmasterId ?? "", name, email });
 
       return undefined;
     },

--- a/apps/web/components/ui/input.tsx
+++ b/apps/web/components/ui/input.tsx
@@ -110,7 +110,7 @@ const Input = forwardRef<
           aria-describedby={description && descriptionId}
           aria-errormessage={error && errorId}
           aria-invalid={!!error}
-          required
+          formNoValidate
           {...props}
         />
 

--- a/apps/web/lib/akismet.ts
+++ b/apps/web/lib/akismet.ts
@@ -1,37 +1,38 @@
+import { kyInstance } from "@/app/get-query-client";
 import { BASE_URL } from "./constants";
 
 const API_KEY = "6c80e09f5c4d";
 
-export default async function checkForSpam(
+const checkForSpam = (
   userIp: string,
   userAgent: string,
   referrer: string,
   commentAuthor: string,
   commentAuthorEmail: string,
   commentContent: string,
-): Promise<boolean> {
-  const body = new URLSearchParams({
-    api_key: API_KEY,
-    blog: BASE_URL,
-    user_ip: userIp,
-    user_agent: userAgent,
-    referrer,
-    comment_type: "contact-form",
-    comment_author: commentAuthor,
-    comment_author_email: commentAuthorEmail,
-    comment_content: commentContent,
-    blog_lang: "en_gb",
-  });
+): Promise<boolean> => {
+  const formData = new FormData();
 
-  const headers = new Headers({
-    "Content-Type": "application/x-www-form-urlencoded",
-  });
+  formData.append("api_key", API_KEY);
+  formData.append("blog", BASE_URL);
+  formData.append("user_ip", userIp);
+  formData.append("user_agent", userAgent);
+  formData.append("referrer", referrer);
+  formData.append("comment_type", "contact-form");
+  formData.append("comment_author", commentAuthor);
+  formData.append("comment_author_email", commentAuthorEmail);
+  formData.append("comment_content", commentContent);
+  formData.append("blog_lang", "en_gb");
 
-  const isSpam = await fetch("https://rest.akismet.com/1.1/comment-check", {
-    method: "POST",
-    headers,
-    body,
-  }).then((res) => res.text());
+  return kyInstance
+    .post("https://rest.akismet.com/1.1/comment-check", {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: formData,
+    })
+    .text()
+    .then((r) => r === "true");
+};
 
-  return isSpam === "true";
-}
+export default checkForSpam;

--- a/apps/web/lib/get-safety-status.ts
+++ b/apps/web/lib/get-safety-status.ts
@@ -1,3 +1,4 @@
+import { kyInstance } from "@/app/get-query-client";
 import { WarningSourceEnum } from "@/components/safety/quoted-warning";
 import type { SafetyComponentProps } from "@/components/safety/safety-component";
 import { EAStationResponseSchema } from "@/types/ea-station-respose";
@@ -39,15 +40,17 @@ const EA_WARNING_URL = `https://environment.data.gov.uk/flood-monitoring/id/floo
 /** Fetches the latest flood warning from the Environment Agency API, using the
  * club's location */
 const fetchEAWarning = () =>
-  fetch(EA_WARNING_URL)
-    .then((res) => res.json())
+  kyInstance
+    .get(EA_WARNING_URL)
+    .json()
     .then(z.object({ items: z.array(EAWarningSchema) }).parse)
     .then((res) => res.items[0]);
 
 /** Fetches monitoring station data from the Environment Agency API */
 const fetchEAStation = () =>
-  fetch("https://environment.data.gov.uk/flood-monitoring/id/stations/E21856")
-    .then((res) => res.json())
+  kyInstance
+    .get("https://environment.data.gov.uk/flood-monitoring/id/stations/E21856")
+    .json()
     .then(z.object({ items: EAStationResponseSchema }).parse)
     .then((res) => res.items);
 

--- a/apps/web/lib/rate-limiter.ts
+++ b/apps/web/lib/rate-limiter.ts
@@ -1,0 +1,29 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import { kv } from "@vercel/kv";
+import { type NextRequest, NextResponse } from "next/server";
+
+export const ratelimiter = new Ratelimit({
+  redis: kv,
+  limiter: Ratelimit.slidingWindow(3, "10s"),
+});
+
+export const routeHandlerRatelimiter = async (req: NextRequest) => {
+  const ip = req.headers.get("x-forwarded-for");
+
+  if (!ip) {
+    return new NextResponse("No IP address in request", {
+      status: 400,
+    });
+  }
+
+  const { success, reset } = await ratelimiter.limit(ip);
+
+  if (!success) {
+    return new NextResponse("Rate limit exceeded", {
+      status: 429,
+      headers: {
+        "Retry-After": Math.ceil((reset - Date.now()) / 1000).toString(),
+      },
+    });
+  }
+};

--- a/apps/web/lib/scrollToSelector.ts
+++ b/apps/web/lib/scrollToSelector.ts
@@ -1,0 +1,11 @@
+export const scrollToSelector = (selector: string) => {
+  const inputElement = window.document.querySelector(selector);
+
+  if (!inputElement) return;
+  inputElement.parentElement?.scrollIntoView({ behavior: "smooth" });
+
+  if (!("focus" in inputElement)) return;
+  if (typeof inputElement.focus !== "function") return;
+
+  inputElement.focus();
+};

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -89,7 +89,7 @@
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "unfurl.js": "^6.4.0",
-    "zod": "^3.24.4"
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@content-collections/core": "^0.8.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -41,10 +41,11 @@
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/postcss": "^4.1.5",
     "@tailwindcss/typography": "^0.5.16",
-    "@tanstack/react-form": "^0.40.4",
+    "@tanstack/react-form": "^1.11.1",
     "@tanstack/react-query": "^5.66.0",
     "@tanstack/react-query-devtools": "^5.66.0",
     "@tanstack/react-table": "^8.21.2",
+    "@upstash/ratelimit": "^2.0.5",
     "@vercel/kv": "^3.0.0",
     "algoliasearch": "^4.24.0",
     "bowser": "^2.11.0",
@@ -64,7 +65,7 @@
     "indefinite": "^2.5.1",
     "inter-ui": "^4.1.0",
     "isomorphic-dompurify": "^2.21.0",
-    "ky": "^1.7.4",
+    "ky": "^1.8.1",
     "lucide-react": "^0.469.0",
     "motion": "12.0.0-alpha.2",
     "next": "15.3.1",
@@ -77,7 +78,6 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-email": "^3.0.6",
-    "react-final-form": "^6.5.9",
     "react-icons": "^5.4.0",
     "react-scroll": "^1.9.0",
     "react-textarea-autosize": "^8.5.7",
@@ -89,7 +89,7 @@
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "unfurl.js": "^6.4.0",
-    "zod": "^3.24.1"
+    "zod": "^3.24.4"
   },
   "devDependencies": {
     "@content-collections/core": "^0.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,7 +318,7 @@ importers:
         specifier: ^6.4.0
         version: 6.4.0
       zod:
-        specifier: ^3.24.4
+        specifier: ^3.24.1
         version: 3.24.4
     devDependencies:
       '@content-collections/core':
@@ -413,7 +413,7 @@ importers:
         version: 8.4.0(typescript@5.8.3)
       zod:
         specifier: ^3.24.1
-        version: 3.24.3
+        version: 3.24.4
     devDependencies:
       '@sudburyrc/tsconfig':
         specifier: workspace:*
@@ -16375,10 +16375,6 @@ packages:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
-    dev: false
-
-  /zod@3.24.3:
-    resolution: {integrity: sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==}
     dev: false
 
   /zod@3.24.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,8 +174,8 @@ importers:
         specifier: ^0.5.16
         version: 0.5.16(tailwindcss@4.1.5)
       '@tanstack/react-form':
-        specifier: ^0.40.4
-        version: 0.40.4(react-dom@19.1.0)(react@19.1.0)(typescript@5.8.3)
+        specifier: ^1.11.1
+        version: 1.11.1(react-dom@19.1.0)(react@19.1.0)
       '@tanstack/react-query':
         specifier: ^5.66.0
         version: 5.74.11(react@19.1.0)
@@ -185,6 +185,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.21.2
         version: 8.21.3(react-dom@19.1.0)(react@19.1.0)
+      '@upstash/ratelimit':
+        specifier: ^2.0.5
+        version: 2.0.5(@upstash/redis@1.34.9)
       '@vercel/kv':
         specifier: ^3.0.0
         version: 3.0.0
@@ -243,7 +246,7 @@ importers:
         specifier: ^2.21.0
         version: 2.24.0
       ky:
-        specifier: ^1.7.4
+        specifier: ^1.8.1
         version: 1.8.1
       lucide-react:
         specifier: ^0.469.0
@@ -281,9 +284,6 @@ importers:
       react-email:
         specifier: ^3.0.6
         version: 3.0.7(react-dom@19.1.0)(react@19.1.0)
-      react-final-form:
-        specifier: ^6.5.9
-        version: 6.5.9(final-form@4.20.10)(react@19.1.0)
       react-icons:
         specifier: ^5.4.0
         version: 5.5.0(react@19.1.0)
@@ -318,8 +318,8 @@ importers:
         specifier: ^6.4.0
         version: 6.4.0
       zod:
-        specifier: ^3.24.1
-        version: 3.24.3
+        specifier: ^3.24.4
+        version: 3.24.4
     devDependencies:
       '@content-collections/core':
         specifier: ^0.8.0
@@ -2074,7 +2074,7 @@ packages:
       tinyglobby: 0.2.13
       typescript: 5.8.3
       yaml: 2.7.1
-      zod: 3.24.3
+      zod: 3.24.4
 
   /@content-collections/integrations@0.2.1(@content-collections/core@0.8.2):
     resolution: {integrity: sha512-AyEcS2MmcOXSYt6vNmJsAiu6EBYjtNiwYGUVUmpG3llm8Gt8uiNrhIhlHyv3cuk+N8KJ2PWemLcMqtQJ+sW3bA==}
@@ -5535,88 +5535,6 @@ packages:
       react: 19.1.0
     dev: false
 
-  /@remix-run/node@2.16.5(typescript@5.8.3):
-    resolution: {integrity: sha512-awunS1kgFmc8q7sGz7FpGf66RXQm2Vw0yk5IFTIJa0WdQrskqyF/6CO+tEf/0np/OCu2fQ23+EfxY2qGHm1aOg==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      typescript: ^5.1.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@remix-run/server-runtime': 2.16.5(typescript@5.8.3)
-      '@remix-run/web-fetch': 4.4.2
-      '@web3-storage/multipart-parser': 1.0.0
-      cookie-signature: 1.2.2
-      source-map-support: 0.5.21
-      stream-slice: 0.1.2
-      typescript: 5.8.3
-      undici: 6.21.2
-    dev: false
-
-  /@remix-run/router@1.23.0:
-    resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
-    engines: {node: '>=14.0.0'}
-    dev: false
-
-  /@remix-run/server-runtime@2.16.5(typescript@5.8.3):
-    resolution: {integrity: sha512-LGGNEJoior2zvgtqyPC5tVPucAvewovQvL4ztC5yE8ZszHmLri9bB9YYWvHqsiT+EaunKHNLmI8jpJHe3PEKhA==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      typescript: ^5.1.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@remix-run/router': 1.23.0
-      '@types/cookie': 0.6.0
-      '@web3-storage/multipart-parser': 1.0.0
-      cookie: 0.7.2
-      set-cookie-parser: 2.7.1
-      source-map: 0.7.4
-      turbo-stream: 2.4.0
-      typescript: 5.8.3
-    dev: false
-
-  /@remix-run/web-blob@3.1.0:
-    resolution: {integrity: sha512-owGzFLbqPH9PlKb8KvpNJ0NO74HWE2euAn61eEiyCXX/oteoVzTVSN8mpLgDjaxBf2btj5/nUllSUgpyd6IH6g==}
-    dependencies:
-      '@remix-run/web-stream': 1.1.0
-      web-encoding: 1.1.5
-    dev: false
-
-  /@remix-run/web-fetch@4.4.2:
-    resolution: {integrity: sha512-jgKfzA713/4kAW/oZ4bC3MoLWyjModOVDjFPNseVqcJKSafgIscrYL9G50SurEYLswPuoU3HzSbO0jQCMYWHhA==}
-    engines: {node: ^10.17 || >=12.3}
-    dependencies:
-      '@remix-run/web-blob': 3.1.0
-      '@remix-run/web-file': 3.1.0
-      '@remix-run/web-form-data': 3.1.0
-      '@remix-run/web-stream': 1.1.0
-      '@web3-storage/multipart-parser': 1.0.0
-      abort-controller: 3.0.0
-      data-uri-to-buffer: 3.0.1
-      mrmime: 1.0.1
-    dev: false
-
-  /@remix-run/web-file@3.1.0:
-    resolution: {integrity: sha512-dW2MNGwoiEYhlspOAXFBasmLeYshyAyhIdrlXBi06Duex5tDr3ut2LFKVj7tyHLmn8nnNwFf1BjNbkQpygC2aQ==}
-    dependencies:
-      '@remix-run/web-blob': 3.1.0
-    dev: false
-
-  /@remix-run/web-form-data@3.1.0:
-    resolution: {integrity: sha512-NdeohLMdrb+pHxMQ/Geuzdp0eqPbea+Ieo8M8Jx2lGC6TBHsgHzYcBvr0LyPdPVycNRDEpWpiDdCOdCryo3f9A==}
-    dependencies:
-      web-encoding: 1.1.5
-    dev: false
-
-  /@remix-run/web-stream@1.1.0:
-    resolution: {integrity: sha512-KRJtwrjRV5Bb+pM7zxcTJkhIqWWSy+MYsIxHK+0m5atcznsf15YwUBWHWulZerV2+vvHH1Lp1DD7pw6qKW8SgA==}
-    dependencies:
-      web-streams-polyfill: 3.3.3
-    dev: false
-
   /@rexxars/react-json-inspector@9.0.1(react@19.1.0):
     resolution: {integrity: sha512-4uZ4RnrVoOGOShIKKcPoF+qhwDCZJsPPqyoEoW/8HRdzNknN9Q2yhlbEgTX1lMZunF1fv7iHzAs+n1vgIgfg/g==}
     peerDependencies:
@@ -6007,7 +5925,7 @@ packages:
       groq-js: 1.16.1
       json5: 2.2.3
       tsconfig-paths: 4.2.0
-      zod: 3.24.3
+      zod: 3.24.4
     transitivePeerDependencies:
       - supports-color
 
@@ -7444,10 +7362,10 @@ packages:
       tailwindcss: 4.1.5
     dev: false
 
-  /@tanstack/form-core@0.40.4:
-    resolution: {integrity: sha512-tmqQd9guHfIVHC2UmfHyFw76dtbtWzU5I9Gv4at3DQGpcM52pMOb5LfsdoBO6muFN5mvsYuZHp4UM6YnZ2gTSQ==}
+  /@tanstack/form-core@1.11.1:
+    resolution: {integrity: sha512-rnj6BU2xCELv6Owm6G6XNjvleQyIIXdYtdl6FF0SF5mWcc1yNic9qWSVAeiYtVy9LgK6i7XW7KuNYAgJDaLxbQ==}
     dependencies:
-      '@tanstack/store': 0.6.0
+      '@tanstack/store': 0.7.0
     dev: false
 
   /@tanstack/query-core@5.74.9:
@@ -7462,23 +7380,25 @@ packages:
     resolution: {integrity: sha512-nSNlfuGdnHf4yB0S+BoNYOE1o3oAH093weAYZolIHfS2stulyA/gWfSk/9H4ZFk5mAAHb5vNqAeJOmbdcGPEQw==}
     dev: false
 
-  /@tanstack/react-form@0.40.4(react-dom@19.1.0)(react@19.1.0)(typescript@5.8.3):
-    resolution: {integrity: sha512-gdHE10EoUaJd3chVEgG6u7dwzjDPu/Mkx64JsxnQK/zJjUD0ZSh0EErb6EJ1gptMtQNYIXz2EofwkTBBKcYqSg==}
+  /@tanstack/react-form@1.11.1(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-7Zi3QD30U+4HLW2UwSWxhiIpwOltRLFPFUY1BcF41xRkr/AMQN1PGgxRF/uOXu/Esydj7dMGunViuPcz41hY/A==}
     peerDependencies:
-      '@tanstack/start': ^1.43.13
+      '@tanstack/react-start': ^1.112.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      vinxi: ^0.5.0
     peerDependenciesMeta:
-      '@tanstack/start':
+      '@tanstack/react-start':
+        optional: true
+      vinxi:
         optional: true
     dependencies:
-      '@remix-run/node': 2.16.5(typescript@5.8.3)
-      '@tanstack/form-core': 0.40.4
-      '@tanstack/react-store': 0.6.1(react-dom@19.1.0)(react@19.1.0)
-      decode-formdata: 0.8.0
+      '@tanstack/form-core': 1.11.1
+      '@tanstack/react-store': 0.7.0(react-dom@19.1.0)(react@19.1.0)
+      decode-formdata: 0.9.0
+      devalue: 5.1.1
       react: 19.1.0
     transitivePeerDependencies:
       - react-dom
-      - typescript
     dev: false
 
   /@tanstack/react-query-devtools@5.74.11(@tanstack/react-query@5.74.11)(react@19.1.0):
@@ -7510,13 +7430,13 @@ packages:
       react: 19.1.0
     dev: false
 
-  /@tanstack/react-store@0.6.1(react-dom@19.1.0)(react@19.1.0):
-    resolution: {integrity: sha512-6gOopOpPp1cAXkEyTEv6tMbAywwFunvIdCKN/SpEiButUayjXU+Q5Sp5Y3hREN3VMR4OA5+RI5SPhhJoqP9e4w==}
+  /@tanstack/react-store@0.7.0(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-S/Rq17HaGOk+tQHV/yrePMnG1xbsKZIl/VsNWnNXt4XW+tTY8dTlvpJH2ZQ3GRALsusG5K6Q3unAGJ2pd9W/Ng==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     dependencies:
-      '@tanstack/store': 0.6.0
+      '@tanstack/store': 0.7.0
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       use-sync-external-store: 1.5.0(react@19.1.0)
@@ -7545,8 +7465,8 @@ packages:
       react-dom: 19.1.0(react@19.1.0)
     dev: false
 
-  /@tanstack/store@0.6.0:
-    resolution: {integrity: sha512-+m2OBglsjXcLmmKOX6/9v8BDOCtyxhMmZLsRUDswOOSdIIR9mvv6i0XNKsmTh3AlYU8c1mRcodC8/Vyf+69VlQ==}
+  /@tanstack/store@0.7.0:
+    resolution: {integrity: sha512-CNIhdoUsmD2NolYuaIs8VfWM467RK6oIBAW4nPEKZhg1smZ+/CwtCdpURgp7nxSqOaV9oKkzdWD80+bC66F/Jg==}
     dev: false
 
   /@tanstack/table-core@8.21.3:
@@ -7610,10 +7530,6 @@ packages:
     dependencies:
       '@types/color-convert': 2.0.4
     dev: true
-
-  /@types/cookie@0.6.0:
-    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
-    dev: false
 
   /@types/cors@2.8.17:
     resolution: {integrity: sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==}
@@ -7875,8 +7791,30 @@ packages:
   /@ungap/structured-clone@1.3.0:
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  /@upstash/core-analytics@0.0.10:
+    resolution: {integrity: sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@upstash/redis': 1.34.8
+    dev: false
+
+  /@upstash/ratelimit@2.0.5(@upstash/redis@1.34.9):
+    resolution: {integrity: sha512-1FRv0cs3ZlBjCNOCpCmKYmt9BYGIJf0J0R3pucOPE88R21rL7jNjXG+I+rN/BVOvYJhI9niRAS/JaSNjiSICxA==}
+    peerDependencies:
+      '@upstash/redis': ^1.34.3
+    dependencies:
+      '@upstash/core-analytics': 0.0.10
+      '@upstash/redis': 1.34.9
+    dev: false
+
   /@upstash/redis@1.34.8:
     resolution: {integrity: sha512-eGJgOKc+2Uq4AdSM0lNx+WvFFhQeyhJ32SGNuSniLPg4lNb6m5h2AQ77qL+TgWiMZO8HCQ82Zsc/RlVBevCWTg==}
+    dependencies:
+      crypto-js: 4.2.0
+    dev: false
+
+  /@upstash/redis@1.34.9:
+    resolution: {integrity: sha512-7qzzF2FQP5VxR2YUNjemWs+hl/8VzJJ6fOkT7O7kt9Ct8olEVzb1g6/ik6B8Pb8W7ZmYv81SdlVV9F6O8bh/gw==}
     dependencies:
       crypto-js: 4.2.0
     dev: false
@@ -7955,10 +7893,6 @@ packages:
       pretty-format: 29.7.0
     dev: true
 
-  /@web3-storage/multipart-parser@1.0.0:
-    resolution: {integrity: sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==}
-    dev: false
-
   /@xstate/react@5.0.3(@types/react@19.1.2)(react@19.1.0)(xstate@5.19.2):
     resolution: {integrity: sha512-Zdnn0VTPcVdoaAiW0OX6Nkvdoe7SNGjfaZqM61NKhjt2aNULqiicmDu2tOd1ChzlRWYDxGTdbzVqqVyMLpoHJw==}
     peerDependencies:
@@ -7992,12 +7926,6 @@ packages:
     transitivePeerDependencies:
       - '@types/react'
     dev: false
-
-  /@zxing/text-encoding@0.9.0:
-    resolution: {integrity: sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==}
-    requiresBuild: true
-    dev: false
-    optional: true
 
   /abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -8204,13 +8132,6 @@ packages:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
     dev: false
 
-  /available-typed-arrays@1.0.7:
-    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      possible-typed-array-names: 1.1.0
-    dev: false
-
   /b4a@1.6.7:
     resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
     dev: false
@@ -8412,24 +8333,6 @@ packages:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
-    dev: false
-
-  /call-bind@1.0.8:
-    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      get-intrinsic: 1.3.0
-      set-function-length: 1.2.2
-    dev: false
-
-  /call-bound@1.0.4:
-    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      get-intrinsic: 1.3.0
     dev: false
 
   /callsites@3.1.0:
@@ -8773,11 +8676,6 @@ packages:
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  /cookie-signature@1.2.2:
-    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
-    engines: {node: '>=6.6.0'}
-    dev: false
-
   /cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
@@ -8906,11 +8804,6 @@ packages:
     resolution: {integrity: sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ==}
     dev: false
 
-  /data-uri-to-buffer@3.0.1:
-    resolution: {integrity: sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==}
-    engines: {node: '>= 6'}
-    dev: false
-
   /data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
@@ -9001,8 +8894,8 @@ packages:
     resolution: {integrity: sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==}
     dev: false
 
-  /decode-formdata@0.8.0:
-    resolution: {integrity: sha512-iUzDgnWsw5ToSkFY7VPFA5Gfph6ROoOxOB7Ybna4miUSzLZ4KaSJk6IAB2AdW6+C9vCVWhjjNA4gjT6wF3eZHQ==}
+  /decode-formdata@0.9.0:
+    resolution: {integrity: sha512-q5uwOjR3Um5YD+ZWPOF/1sGHVW9A5rCrRwITQChRXlmPkxDFBqCm4jNTIVdGHNH9OnR+V9MoZVgRhsFb+ARbUw==}
     dev: false
 
   /decode-named-character-reference@1.1.0:
@@ -9087,15 +8980,6 @@ packages:
       clone: 1.0.4
     dev: false
 
-  /define-data-property@1.1.4:
-    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      gopd: 1.2.0
-    dev: false
-
   /define-lazy-prop@2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
@@ -9128,6 +9012,10 @@ packages:
 
   /detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+    dev: false
+
+  /devalue@5.1.1:
+    resolution: {integrity: sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==}
     dev: false
 
   /devlop@1.1.0:
@@ -9831,13 +9719,6 @@ packages:
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
 
-  /for-each@0.3.5:
-    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      is-callable: 1.2.7
-    dev: false
-
   /foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
@@ -10258,12 +10139,6 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
-  /has-property-descriptors@1.0.2:
-    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
-    dependencies:
-      es-define-property: 1.0.1
-    dev: false
-
   /has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -10586,14 +10461,6 @@ packages:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
 
-  /is-arguments@1.2.0:
-    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-    dev: false
-
   /is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
     dev: false
@@ -10606,11 +10473,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       binary-extensions: 2.3.0
-    dev: false
-
-  /is-callable@1.2.7:
-    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
-    engines: {node: '>= 0.4'}
     dev: false
 
   /is-core-module@2.16.1:
@@ -10646,16 +10508,6 @@ packages:
   /is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
-
-  /is-generator-function@1.1.0:
-    resolution: {integrity: sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bound: 1.0.4
-      get-proto: 1.0.1
-      has-tostringtag: 1.0.2
-      safe-regex-test: 1.1.0
-    dev: false
 
   /is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -10723,16 +10575,6 @@ packages:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
     dev: false
 
-  /is-regex@1.2.1:
-    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bound: 1.0.4
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.2
-    dev: false
-
   /is-retry-allowed@2.2.0:
     resolution: {integrity: sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==}
     engines: {node: '>=10'}
@@ -10754,13 +10596,6 @@ packages:
   /is-tar@1.0.0:
     resolution: {integrity: sha512-8sR603bS6APKxcdkQ1e5rAC9JDCxM3OlbGJDWv5ajhHqIh6cTaqcpeOTch1iIeHYY4nHEFTgmCiGSLfvmODH4w==}
     engines: {node: '>=0.10.0'}
-    dev: false
-
-  /is-typed-array@1.1.15:
-    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      which-typed-array: 1.1.19
     dev: false
 
   /is-typedarray@1.0.0:
@@ -12250,11 +12085,6 @@ packages:
       tslib: 2.8.1
     dev: false
 
-  /mrmime@1.0.1:
-    resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
-    engines: {node: '>=10'}
-    dev: false
-
   /mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -13031,11 +12861,6 @@ packages:
       '@babel/runtime': 7.27.1
     dev: false
 
-  /possible-typed-array-names@1.1.0:
-    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
-    engines: {node: '>= 0.4'}
-    dev: false
-
   /postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
@@ -13359,17 +13184,6 @@ packages:
 
   /react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
-    dev: false
-
-  /react-final-form@6.5.9(final-form@4.20.10)(react@19.1.0):
-    resolution: {integrity: sha512-x3XYvozolECp3nIjly+4QqxdjSSWfcnpGEL5K8OBT6xmGrq5kBqbA6+/tOqoom9NwqIPPbxPNsOViFlbKgowbA==}
-    peerDependencies:
-      final-form: ^4.20.4
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.27.0
-      final-form: 4.20.10
-      react: 19.1.0
     dev: false
 
   /react-focus-lock@2.13.6(@types/react@19.1.2)(react@19.1.0):
@@ -14143,15 +13957,6 @@ packages:
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
-  /safe-regex-test@1.1.0:
-    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-regex: 1.2.1
-    dev: false
-
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -14618,22 +14423,6 @@ packages:
     dependencies:
       randombytes: 2.1.0
 
-  /set-cookie-parser@2.7.1:
-    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
-    dev: false
-
-  /set-function-length@1.2.2:
-    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      define-data-property: 1.1.4
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-      get-intrinsic: 1.3.0
-      gopd: 1.2.0
-      has-property-descriptors: 1.0.2
-    dev: false
-
   /shallow-clone@3.0.1:
     resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
     engines: {node: '>=8'}
@@ -14954,10 +14743,6 @@ packages:
 
   /stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
-    dev: false
-
-  /stream-slice@0.1.2:
-    resolution: {integrity: sha512-QzQxpoacatkreL6jsxnVb7X5R/pGw9OUv2qWTYWnmLpg4NdN31snPy/f3TdQE1ZUXaThRvj1Zw4/OGg0ZkaLMA==}
     dev: false
 
   /streamsearch@1.1.0:
@@ -15560,10 +15345,6 @@ packages:
     dev: false
     optional: true
 
-  /turbo-stream@2.4.0:
-    resolution: {integrity: sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==}
-    dev: false
-
   /turbo-windows-64@2.5.2:
     resolution: {integrity: sha512-hOLcbgZzE5ttACHHyc1ajmWYq4zKT42IC3G6XqgiXxMbS+4eyVYTL+7UvCZBd3Kca1u4TLQdLQjeO76zyDJc2A==}
     cpu: [x64]
@@ -15666,11 +15447,6 @@ packages:
     engines: {node: '>=14.0'}
     dependencies:
       '@fastify/busboy': 2.1.1
-
-  /undici@6.21.2:
-    resolution: {integrity: sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==}
-    engines: {node: '>=18.17'}
-    dev: false
 
   /unfurl.js@6.4.0:
     resolution: {integrity: sha512-DogJFWPkOWMcu2xPdpmbcsL+diOOJInD3/jXOv6saX1upnWmMK8ndAtDWUfJkuInqNI9yzADud4ID9T+9UeWCw==}
@@ -15990,16 +15766,6 @@ packages:
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  /util@0.12.5:
-    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
-    dependencies:
-      inherits: 2.0.4
-      is-arguments: 1.2.0
-      is-generator-function: 1.1.0
-      is-typed-array: 1.1.15
-      which-typed-array: 1.1.19
-    dev: false
-
   /uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
@@ -16269,19 +16035,6 @@ packages:
       defaults: 1.0.4
     dev: false
 
-  /web-encoding@1.1.5:
-    resolution: {integrity: sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==}
-    dependencies:
-      util: 0.12.5
-    optionalDependencies:
-      '@zxing/text-encoding': 0.9.0
-    dev: false
-
-  /web-streams-polyfill@3.3.3:
-    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
-    engines: {node: '>= 8'}
-    dev: false
-
   /web-vitals@4.2.4:
     resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
     dev: false
@@ -16367,19 +16120,6 @@ packages:
     engines: {node: '>=18.12'}
     dependencies:
       load-yaml-file: 0.2.0
-    dev: false
-
-  /which-typed-array@1.1.19:
-    resolution: {integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      for-each: 0.3.5
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
     dev: false
 
   /which@2.0.2:
@@ -16639,6 +16379,10 @@ packages:
 
   /zod@3.24.3:
     resolution: {integrity: sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==}
+    dev: false
+
+  /zod@3.24.4:
+    resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
 
   /zustand@5.0.4(@types/react@19.1.2)(react@19.1.0)(use-sync-external-store@1.5.0):
     resolution: {integrity: sha512-39VFTN5InDtMd28ZhjLyuTnlytDr9HfwO512Ai4I8ZABCoyAj4F1+sr7sD1jP/+p7k77Iko0Pb5NhgBFDCX0kQ==}


### PR DESCRIPTION
Use `@upstash/ratelimit` with exisiting Vercel KV store. Provide `Retry-After` header with 429 responses.

In addition:
- replace direct client-side `fetch()` calls with `ky`, which has built in retry delay when a `Retry-After` header is provided
- disable React Query's built-in retries, which were duplicating `ky`'s (and the Sanity SDK's)
- modify the form POST logic, and add a `ky` hook to unwrap the text body of error responses for use as an user-facing error message
- tangentially, remove `react-final-form` and migrate the bug-reporting form to using `@tanstack/react-form`
- upgrade `@tanstack/react-form` to v1