### PR TITLE
refactor(nav): replace Popover with NavigationMenu for mobile navigation

### DIFF
--- a/apps/web/components/nav/desktop-menu/nav-section.tsx
+++ b/apps/web/components/nav/desktop-menu/nav-section.tsx
@@ -1,18 +1,19 @@
 "use client";
 
+import {
+  NavigationMenu,
+  NavigationMenuContent,
+  NavigationMenuIndicator,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+  NavigationMenuTrigger,
+  NavigationMenuViewport,
+} from "@/components/ui/navigation-menu";
 import { cn } from "@/lib/utils";
 import type { IconNavItemType } from "@/types/nav-item";
-import {
-  CloseButton,
-  Popover,
-  PopoverButton,
-  Transition,
-} from "@headlessui/react";
-import { ChevronDownIcon } from "@heroicons/react/20/solid";
-import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { fork } from "radash";
-import { Fragment } from "react";
 
 export const navLinkClasses = cn(
   "group inline-flex rounded-md px-2 py-2.5 text-sm transition hover:text-black md:px-3",
@@ -24,64 +25,6 @@ const POPOVER_PANEL_CLASSES = new Map<boolean, string>([
   [true, "max-w-sm right-0"],
   [false, "w-screen max-w-xs -translate-x-1/2 left-1/2"],
 ]);
-
-const ListItem = ({
-  href,
-  name,
-  description,
-  icon,
-  mobileOnly,
-  cta,
-}: IconNavItemType) => {
-  if (mobileOnly) return null;
-
-  const Icon = icon || null;
-
-  return (
-    <CloseButton
-      as={Link}
-      key={href}
-      href={href}
-      className={cn(
-        "group flex rounded-sm transition",
-        description ? "items-start" : "items-center",
-      )}
-    >
-      {Icon && (
-        <Icon
-          className="mr-2.5 h-6 w-6 shrink-0 text-blue-700 transition-colors group-hover:text-blue-500"
-          aria-hidden
-        />
-      )}
-      <div className="flex flex-col">
-        <p
-          className={cn(
-            "flex py-0.5 font-semibold text-sm leading-none transition-colors",
-            {
-              "text-gray-900 group-hover:text-gray-700": cta,
-              "text-gray-600 group-hover:text-gray-900": !cta,
-            },
-          )}
-        >
-          {name}
-          {!cta && (
-            <span
-              aria-hidden
-              className="block scale-y-90 opacity-0 transition group-hover:translate-x-1 group-hover:scale-x-110 group-hover:opacity-100"
-            >
-              &rarr;
-            </span>
-          )}
-        </p>
-        {description && (
-          <p className="font-medium text-gray-500 text-xs transition-colors group-hover:text-gray-900">
-            {description}
-          </p>
-        )}
-      </div>
-    </CloseButton>
-  );
-};
 
 type NavSectionProps = {
   compact?: boolean;
@@ -102,101 +45,137 @@ const NavSection = ({
   if (items.length === 1) {
     const { href, name } = items[0];
     return (
-      <Link
+      <NavigationMenuLink
         href={href}
         className={cn(isActive ? navLinkActive : navLinkColor, navLinkClasses)}
       >
         {name}
-      </Link>
+      </NavigationMenuLink>
     );
   }
 
   const [primaryItems, ctaItems] = fork(items, ({ cta }) => !cta);
 
   return (
-    <Popover className="relative">
-      {({ open }) => (
-        <>
-          <PopoverButton
+    <NavigationMenu>
+      <NavigationMenuList>
+        <NavigationMenuItem>
+          <NavigationMenuTrigger
             className={cn(
-              isActive || open ? navLinkActive : navLinkColor,
+              isActive ? navLinkActive : navLinkColor,
               navLinkClasses,
               "items-center",
             )}
             aria-current={isActive ? "page" : undefined}
           >
-            <>
-              <span className={cn(icon && "sr-only")}>{label}</span>
-              {icon}
-
-              <ChevronDownIcon
-                className={cn(
-                  isActive ? "stroke-current text-gray-700" : "text-gray-400",
-                  "-mb-px ml-0.5 h-3 w-3 transition group-hover:text-gray-800",
-                )}
-                aria-hidden
-              />
-            </>
-          </PopoverButton>
-
-          <Transition
-            show={open}
-            as={Fragment}
-            enter="transition ease-in-out delay-75 duration-100"
-            enterFrom="translate-y-8 opacity-0"
-            enterTo="translate-y-0 opacity-100"
-            leave="transition ease-in duration-75"
-            leaveFrom="translate-y-0 opacity-100"
-            leaveTo="translate-y-8 opacity-0"
+            <span className={cn(icon && "sr-only")}>{label}</span>
+            {icon}
+          </NavigationMenuTrigger>
+          <NavigationMenuContent
+            className={cn(POPOVER_PANEL_CLASSES.get(compact))}
           >
-            <div
-              aria-hidden
-              className="absolute top-12 right-1/2 h-6 w-6 rotate-45 rounded-xs bg-gray-200 bg-opacity-75 shadow-sm backdrop-blur-sm"
-            />
-          </Transition>
-
-          <Transition
-            show={open}
-            as={Fragment}
-            enter="transition ease-in-out duration-75"
-            enterFrom="opacity-0 -translate-y-10"
-            enterTo="opacity-100 translate-y-0"
-            leave="transition ease-in-out duration-200"
-            leaveFrom="opacity-100 translate-y-0"
-            leaveTo="opacity-0 -translate-y-2"
-          >
-            <Popover.Panel
-              static
-              className={cn(
-                "absolute z-20 mt-3 transform px-2 sm:px-0",
-                POPOVER_PANEL_CLASSES.get(compact),
-              )}
-            >
-              <div className="overflow-hidden rounded-md bg-gray-200 bg-opacity-75 p-1 shadow-lg backdrop-blur-sm">
-                <div className="relative grid gap-4 rounded-xs bg-white p-2 shadow-sm">
-                  {primaryItems.map((item) => (
-                    <ListItem key={item.href} {...item} />
-                  ))}
-                </div>
-
-                <div
-                  className={cn(
-                    "pt-3 pb-2",
-                    compact
-                      ? "space-y-4 pr-4 pl-3"
-                      : "flex space-x-6 space-y-0 px-2",
-                  )}
-                >
-                  {ctaItems.map((item) => (
-                    <ListItem key={item.href} {...item} />
-                  ))}
-                </div>
+            <div className="overflow-hidden rounded-md bg-gray-200 bg-opacity-75 p-1 shadow-lg backdrop-blur-sm">
+              <div className="relative grid gap-4 rounded-xs bg-white p-2 shadow-sm">
+                {primaryItems.map((item) => (
+                  <NavigationMenuLink
+                    key={item.href}
+                    href={item.href}
+                    className="group flex rounded-sm transition"
+                  >
+                    {item.icon && (
+                      <item.icon
+                        className="mr-2.5 h-6 w-6 shrink-0 text-blue-700 transition-colors group-hover:text-blue-500"
+                        aria-hidden
+                      />
+                    )}
+                    <div className="flex flex-col">
+                      <p
+                        className={cn(
+                          "flex py-0.5 font-semibold text-sm leading-none transition-colors",
+                          {
+                            "text-gray-900 group-hover:text-gray-700": item.cta,
+                            "text-gray-600 group-hover:text-gray-900":
+                              !item.cta,
+                          },
+                        )}
+                      >
+                        {item.name}
+                        {!item.cta && (
+                          <span
+                            aria-hidden
+                            className="block scale-y-90 opacity-0 transition group-hover:translate-x-1 group-hover:scale-x-110 group-hover:opacity-100"
+                          >
+                            &rarr;
+                          </span>
+                        )}
+                      </p>
+                      {item.description && (
+                        <p className="font-medium text-gray-500 text-xs transition-colors group-hover:text-gray-900">
+                          {item.description}
+                        </p>
+                      )}
+                    </div>
+                  </NavigationMenuLink>
+                ))}
               </div>
-            </Popover.Panel>
-          </Transition>
-        </>
-      )}
-    </Popover>
+
+              <div
+                className={cn(
+                  "pt-3 pb-2",
+                  compact
+                    ? "space-y-4 pr-4 pl-3"
+                    : "flex space-x-6 space-y-0 px-2",
+                )}
+              >
+                {ctaItems.map((item) => (
+                  <NavigationMenuLink
+                    key={item.href}
+                    href={item.href}
+                    className="group flex rounded-sm transition"
+                  >
+                    {item.icon && (
+                      <item.icon
+                        className="mr-2.5 h-6 w-6 shrink-0 text-blue-700 transition-colors group-hover:text-blue-500"
+                        aria-hidden
+                      />
+                    )}
+                    <div className="flex flex-col">
+                      <p
+                        className={cn(
+                          "flex py-0.5 font-semibold text-sm leading-none transition-colors",
+                          {
+                            "text-gray-900 group-hover:text-gray-700": item.cta,
+                            "text-gray-600 group-hover:text-gray-900":
+                              !item.cta,
+                          },
+                        )}
+                      >
+                        {item.name}
+                        {!item.cta && (
+                          <span
+                            aria-hidden
+                            className="block scale-y-90 opacity-0 transition group-hover:translate-x-1 group-hover:scale-x-110 group-hover:opacity-100"
+                          >
+                            &rarr;
+                          </span>
+                        )}
+                      </p>
+                      {item.description && (
+                        <p className="font-medium text-gray-500 text-xs transition-colors group-hover:text-gray-900">
+                          {item.description}
+                        </p>
+                      )}
+                    </div>
+                  </NavigationMenuLink>
+                ))}
+              </div>
+            </div>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+      <NavigationMenuIndicator />
+      <NavigationMenuViewport />
+    </NavigationMenu>
   );
 };
 

--- a/apps/web/components/nav/mobile-menu/mobile-menu-button.tsx
+++ b/apps/web/components/nav/mobile-menu/mobile-menu-button.tsx
@@ -1,12 +1,16 @@
-import { PopoverButton } from "@headlessui/react";
+import { Button } from "@/components/ui/button";
 import { Bars3Icon } from "@heroicons/react/24/outline";
 
 const MobileMenuButton = () => (
   <div className="-my-2 -mr-2 sm:hidden">
-    <PopoverButton className="inline-flex items-center justify-center rounded-md p-2 text-gray-40 transition hover:bg-gray-100 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-white focus:ring-inset">
+    <Button
+      variant="ghost"
+      size="icon"
+      className="inline-flex items-center justify-center rounded-md p-2 text-gray-40 transition hover:bg-gray-100 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-white focus:ring-inset"
+    >
       <span className="sr-only">Open menu</span>
       <Bars3Icon className="h-6 w-6" aria-hidden />
-    </PopoverButton>
+    </Button>
   </div>
 );
 

--- a/apps/web/components/nav/mobile-menu/mobile-menu-section.tsx
+++ b/apps/web/components/nav/mobile-menu/mobile-menu-section.tsx
@@ -1,8 +1,12 @@
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 import { cn } from "@/lib/utils";
 import type { IconNavItemType } from "@/types/nav-item";
-import { CloseButton } from "@headlessui/react";
 import { ChevronDownIcon } from "@heroicons/react/20/solid";
-import * as Accordion from "@radix-ui/react-accordion";
 import Link from "next/link";
 
 type SectionProps = {
@@ -42,9 +46,9 @@ const SectionWrapper = ({
 
   if (collapse)
     return (
-      <Accordion.Root type="single" collapsible>
-        <Accordion.Item className={outer} value={title}>
-          <Accordion.Trigger
+      <Accordion type="single" collapsible>
+        <AccordionItem className={outer} value={title}>
+          <AccordionTrigger
             className={cn(
               titleClasses,
               "-my-4 [&[data-state=open]>svg]:-rotate-180 flex w-full justify-between py-4",
@@ -55,17 +59,17 @@ const SectionWrapper = ({
               aria-hidden
               className="h-4 w-4 transition-transform duration-200"
             />
-          </Accordion.Trigger>
-          <Accordion.Content
+          </AccordionTrigger>
+          <AccordionContent
             className={cn(
               panel,
               "transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down data-[state=closed]:opacity-0 data-[state=open]:opacity-100",
             )}
           >
             {inner}
-          </Accordion.Content>
-        </Accordion.Item>
-      </Accordion.Root>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
     );
   return (
     <div className={outer}>
@@ -84,10 +88,8 @@ export const MobileMenuSection = ({
   <SectionWrapper {...{ title, collapse, compact }}>
     {data.map((item) => {
       const Icon = item.icon || null;
-
       return (
-        <CloseButton
-          as={Link}
+        <Link
           key={item.name}
           href={item.href}
           className="-m-2 flex items-center rounded-md p-2 hover:bg-gray-100"
@@ -101,7 +103,7 @@ export const MobileMenuSection = ({
           <span className="font-medium text-gray-900">
             {item.shortName ? item.shortName : item.name}
           </span>
-        </CloseButton>
+        </Link>
       );
     })}
   </SectionWrapper>

--- a/apps/web/components/nav/nav.tsx
+++ b/apps/web/components/nav/nav.tsx
@@ -1,20 +1,18 @@
 "use client";
 
 import { NavLogo, NavSection } from "@/components/nav";
+import { MobileMenuSection } from "@/components/nav/mobile-menu";
+import { Button } from "@/components/ui/button";
 import {
-  MobileMenuButton,
-  MobileMenuSection,
-} from "@/components/nav/mobile-menu";
-import {
-  Popover,
-  PopoverButton,
-  PopoverGroup,
-  PopoverPanel,
-  Transition,
-} from "@headlessui/react";
+  NavigationMenu,
+  NavigationMenuContent,
+  NavigationMenuItem,
+  NavigationMenuList,
+  NavigationMenuTrigger,
+} from "@/components/ui/navigation-menu";
 import XMarkIcon from "@heroicons/react/24/outline/XMarkIcon";
+import { Bars3Icon } from "lucide-react";
 import { fork } from "radash";
-import { Fragment } from "react";
 import { navigationGroups, secondaryNavigationGroups } from "./nav-data";
 
 const extractSingletonGroups = (
@@ -52,87 +50,72 @@ const Nav = () => {
   );
 
   return (
-    <Popover className="bg-white text-gray-900" id="navbar">
-      {({ open }) => (
-        <>
-          <div className="container flex items-center justify-between px-4! py-3 xs:py-4 md:py-6">
-            <NavLogo />
-            <MobileMenuButton />
-
-            <PopoverGroup as="nav" className="mx-auto hidden sm:flex">
-              {navigationGroups.map(({ title, items }) => (
-                <NavSection key={title} label={title} {...{ items }} />
-              ))}
-            </PopoverGroup>
-
-            <PopoverGroup
-              as="nav"
-              className="hidden items-center justify-end sm:flex lg:w-0 lg:flex-1 "
-            >
-              {secondaryNavigationGroups.map(({ title, items, icon }) => {
-                const Icon = icon || null;
-                return (
-                  <NavSection
-                    key={title}
-                    label={title}
-                    icon={
-                      Icon ? (
-                        <Icon aria-hidden className="flex h-4 w-4" />
-                      ) : undefined
-                    }
-                    compact
-                    {...{ items }}
-                  />
-                );
-              })}
-            </PopoverGroup>
-          </div>
-
-          <Transition
-            show={open}
-            as={Fragment}
-            enter="duration-200 ease-out"
-            enterFrom="opacity-0 scale-95"
-            enterTo="opacity-100 scale-100"
-            leave="duration-100 ease-in"
-            leaveFrom="opacity-100 scale-100"
-            leaveTo="opacity-0 scale-95"
-          >
-            <PopoverPanel
-              focus
-              static
-              className="absolute inset-x-0 top-0 z-20 origin-top-right transform p-2 transition md:hidden"
-            >
-              <div className="relative divide-y rounded-sm bg-white shadow-lg ring-1 ring-black ring-opacity-5">
-                {primaryGroups.map(({ title, items }) => (
-                  <MobileMenuSection
-                    collapse={title.toLowerCase() === "regatta"}
-                    key={title}
-                    title={title}
-                    data={items}
-                  />
-                ))}
-
-                {secondaryGroups.map(({ title, items }) => (
-                  <MobileMenuSection
-                    key={title}
-                    title={title}
-                    data={items}
-                    compact
-                  />
-                ))}
-              </div>
-              <div className="absolute top-3 right-3">
-                <PopoverButton className="inline-flex items-center justify-center rounded-md p-2 text-gray-700 transition hover:bg-gray-100 hover:text-gray-500 focus:outline-hidden">
-                  <span className="sr-only">Close menu</span>
-                  <XMarkIcon className="h-6 w-6" aria-hidden />
-                </PopoverButton>
-              </div>
-            </PopoverPanel>
-          </Transition>
-        </>
-      )}
-    </Popover>
+    <div className="bg-white text-gray-900" id="navbar">
+      <div className="container flex items-center justify-between px-4! py-3 xs:py-4 md:py-6">
+        <NavLogo />
+        {/* Mobile menu trigger */}
+        <NavigationMenu className="sm:hidden">
+          <NavigationMenuList>
+            <NavigationMenuItem>
+              <NavigationMenuTrigger className="border-0 bg-transparent p-0 shadow-none">
+                <span className="sr-only">Open menu</span>
+                <Bars3Icon className="h-6 w-6" aria-hidden />
+              </NavigationMenuTrigger>
+              <NavigationMenuContent className="absolute inset-x-0 top-0 z-20 origin-top-right transform p-2 transition md:hidden">
+                <div className="relative divide-y rounded-sm bg-white shadow-lg ring-1 ring-black ring-opacity-5">
+                  {primaryGroups.map(({ title, items }) => (
+                    <MobileMenuSection
+                      collapse={title.toLowerCase() === "regatta"}
+                      key={title}
+                      title={title}
+                      data={items}
+                    />
+                  ))}
+                  {secondaryGroups.map(({ title, items }) => (
+                    <MobileMenuSection
+                      key={title}
+                      title={title}
+                      data={items}
+                      compact
+                    />
+                  ))}
+                </div>
+                <div className="absolute top-3 right-3">
+                  <Button variant="ghost" size="icon">
+                    <span className="sr-only">Close menu</span>
+                    <XMarkIcon className="h-6 w-6" aria-hidden />
+                  </Button>
+                </div>
+              </NavigationMenuContent>
+            </NavigationMenuItem>
+          </NavigationMenuList>
+        </NavigationMenu>
+        {/* Desktop nav */}
+        <nav className="mx-auto hidden sm:flex">
+          {navigationGroups.map(({ title, items }) => (
+            <NavSection key={title} label={title} {...{ items }} />
+          ))}
+        </nav>
+        <nav className="hidden items-center justify-end sm:flex lg:w-0 lg:flex-1 ">
+          {secondaryNavigationGroups.map(({ title, items, icon }) => {
+            const Icon = icon || null;
+            return (
+              <NavSection
+                key={title}
+                label={title}
+                icon={
+                  Icon ? (
+                    <Icon aria-hidden className="flex h-4 w-4" />
+                  ) : undefined
+                }
+                compact
+                {...{ items }}
+              />
+            );
+          })}
+        </nav>
+      </div>
+    </div>
   );
 };
 

--- a/apps/web/components/ui/navigation-menu.tsx
+++ b/apps/web/components/ui/navigation-menu.tsx
@@ -1,0 +1,169 @@
+import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
+import { cva } from "class-variance-authority";
+import { ChevronDownIcon } from "lucide-react";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function NavigationMenu({
+  className,
+  children,
+  viewport = true,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Root> & {
+  viewport?: boolean;
+}) {
+  return (
+    <NavigationMenuPrimitive.Root
+      data-slot="navigation-menu"
+      data-viewport={viewport}
+      className={cn(
+        "group/navigation-menu relative flex max-w-max flex-1 items-center justify-center",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {viewport && <NavigationMenuViewport />}
+    </NavigationMenuPrimitive.Root>
+  );
+}
+
+function NavigationMenuList({
+  className,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.List>) {
+  return (
+    <NavigationMenuPrimitive.List
+      data-slot="navigation-menu-list"
+      className={cn(
+        "group flex flex-1 list-none items-center justify-center gap-1",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function NavigationMenuItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Item>) {
+  return (
+    <NavigationMenuPrimitive.Item
+      data-slot="navigation-menu-item"
+      className={cn("relative", className)}
+      {...props}
+    />
+  );
+}
+
+const navigationMenuTriggerStyle = cva(
+  "group inline-flex h-9 w-max items-center justify-center rounded-md bg-white px-4 py-2 font-medium text-sm outline-none transition-[color,box-shadow] hover:bg-gray-100 hover:text-gray-900 focus:bg-gray-100 focus:text-gray-900 focus-visible:outline-1 focus-visible:ring-[3px] focus-visible:ring-gray-950/50 disabled:pointer-events-none disabled:opacity-50 data-[state=open]:bg-gray-100/50 data-[state=open]:text-gray-900 data-[state=open]:focus:bg-gray-100 data-[state=open]:hover:bg-gray-100 dark:bg-gray-950 dark:data-[state=open]:bg-gray-800/50 dark:data-[state=open]:text-gray-50 dark:focus-visible:ring-gray-300/50 dark:focus:bg-gray-800 dark:focus:text-gray-50 dark:data-[state=open]:focus:bg-gray-800 dark:hover:bg-gray-800 dark:hover:text-gray-50 dark:data-[state=open]:hover:bg-gray-800",
+);
+
+function NavigationMenuTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Trigger>) {
+  return (
+    <NavigationMenuPrimitive.Trigger
+      data-slot="navigation-menu-trigger"
+      className={cn(navigationMenuTriggerStyle(), "group", className)}
+      {...props}
+    >
+      {children}
+      {""}
+      <ChevronDownIcon
+        className="relative top-[1px] ml-1 size-3 transition duration-300 group-data-[state=open]:rotate-180"
+        aria-hidden="true"
+      />
+    </NavigationMenuPrimitive.Trigger>
+  );
+}
+
+function NavigationMenuContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Content>) {
+  return (
+    <NavigationMenuPrimitive.Content
+      data-slot="navigation-menu-content"
+      className={cn(
+        "data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 top-0 left-0 w-full p-2 pr-2.5 data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out md:absolute md:w-auto",
+        "group-data-[viewport=false]/navigation-menu:data-[state=closed]:zoom-out-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:zoom-in-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:fade-in-0 group-data-[viewport=false]/navigation-menu:data-[state=closed]:fade-out-0 **:data-[slot=navigation-menu-link]:focus:outline-none **:data-[slot=navigation-menu-link]:focus:ring-0 group-data-[viewport=false]/navigation-menu:top-full group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden group-data-[viewport=false]/navigation-menu:rounded-md group-data-[viewport=false]/navigation-menu:border group-data-[viewport=false]/navigation-menu:bg-popover group-data-[viewport=false]/navigation-menu:text-popover-foreground group-data-[viewport=false]/navigation-menu:shadow group-data-[viewport=false]/navigation-menu:duration-200 group-data-[viewport=false]/navigation-menu:data-[state=closed]:animate-out group-data-[viewport=false]/navigation-menu:data-[state=open]:animate-in",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function NavigationMenuViewport({
+  className,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Viewport>) {
+  return (
+    <div
+      className={cn(
+        "absolute top-full left-0 isolate z-50 flex justify-center",
+      )}
+    >
+      <NavigationMenuPrimitive.Viewport
+        data-slot="navigation-menu-viewport"
+        className={cn(
+          "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full origin-top-center overflow-hidden rounded-md border border-gray-200 bg-white text-gray-950 shadow data-[state=closed]:animate-out data-[state=open]:animate-in md:w-[var(--radix-navigation-menu-viewport-width)] dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50",
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function NavigationMenuLink({
+  className,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Link>) {
+  return (
+    <NavigationMenuPrimitive.Link
+      data-slot="navigation-menu-link"
+      className={cn(
+        "flex flex-col gap-1 rounded-sm p-2 text-sm outline-none transition-all hover:bg-gray-100 hover:text-gray-900 focus:bg-gray-100 focus:text-gray-900 focus-visible:outline-1 focus-visible:ring-[3px] focus-visible:ring-gray-950/50 data-[active=true]:bg-gray-100/50 data-[active=true]:text-gray-900 data-[active=true]:focus:bg-gray-100 data-[active=true]:hover:bg-gray-100 dark:data-[active=true]:bg-gray-800/50 dark:data-[active=true]:text-gray-50 dark:focus-visible:ring-gray-300/50 dark:focus:bg-gray-800 dark:focus:text-gray-50 dark:data-[active=true]:focus:bg-gray-800 dark:hover:bg-gray-800 dark:hover:text-gray-50 dark:data-[active=true]:hover:bg-gray-800 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-gray-500 dark:[&_svg:not([class*='text-'])]:text-gray-400",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function NavigationMenuIndicator({
+  className,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Indicator>) {
+  return (
+    <NavigationMenuPrimitive.Indicator
+      data-slot="navigation-menu-indicator"
+      className={cn(
+        "data-[state=hidden]:fade-out data-[state=visible]:fade-in top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden data-[state=hidden]:animate-out data-[state=visible]:animate-in",
+        className,
+      )}
+      {...props}
+    >
+      <div className="relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm bg-gray-200 shadow-md dark:bg-gray-800" />
+    </NavigationMenuPrimitive.Indicator>
+  );
+}
+
+export {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuContent,
+  NavigationMenuTrigger,
+  NavigationMenuLink,
+  NavigationMenuIndicator,
+  NavigationMenuViewport,
+  navigationMenuTriggerStyle,
+};

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
     "@radix-ui/react-dialog": "^1.1.5",
     "@radix-ui/react-dropdown-menu": "^2.1.6",
     "@radix-ui/react-label": "^2.1.6",
+    "@radix-ui/react-navigation-menu": "^1.2.12",
     "@radix-ui/react-slot": "^1.1.1",
     "@radix-ui/react-toggle": "^1.1.1",
     "@radix-ui/react-toggle-group": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,7 +139,7 @@ importers:
         version: 1.1.8(@content-collections/core@0.8.2)(@content-collections/mdx@0.2.2)(fumadocs-core@15.3.1)
       '@headlessui/react':
         specifier: ^2.2.0
-        version: 2.2.2(react-dom@19.1.0)(react@19.1.0)
+        version: 2.2.3(react-dom@19.1.0)(react@19.1.0)
       '@heroicons/react':
         specifier: ^2.2.0
         version: 2.2.0(react@19.1.0)
@@ -170,6 +170,9 @@ importers:
       '@radix-ui/react-label':
         specifier: ^2.1.6
         version: 2.1.6(@types/react-dom@19.1.3)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-navigation-menu':
+        specifier: ^1.2.12
+        version: 1.2.12(@types/react-dom@19.1.3)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
       '@radix-ui/react-slot':
         specifier: ^1.1.1
         version: 1.2.0(@types/react@19.1.2)(react@19.1.0)
@@ -3381,17 +3384,17 @@ packages:
       fumadocs-core: 15.3.1(@types/react@19.1.2)(algoliasearch@4.24.0)(next@15.3.2)(react-dom@19.1.0)(react@19.1.0)
     dev: false
 
-  /@headlessui/react@2.2.2(react-dom@19.1.0)(react@19.1.0):
-    resolution: {integrity: sha512-zbniWOYBQ8GHSUIOPY7BbdIn6PzUOq0z41RFrF30HbjsxG6Rrfk+6QulR8Kgf2Vwj2a/rE6i62q5vo+2gI5dJA==}
+  /@headlessui/react@2.2.3(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-hgOJGXPifPlOczIeSwX8OjLWRJ5XdYApZFf7DeCbCrO1PXHkPhNTRrA9ZwJsgAG7SON1i2JcvIreF/kbgtJeaQ==}
     engines: {node: '>=10'}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
     dependencies:
       '@floating-ui/react': 0.26.28(react-dom@19.1.0)(react@19.1.0)
-      '@react-aria/focus': 3.20.2(react-dom@19.1.0)(react@19.1.0)
-      '@react-aria/interactions': 3.25.0(react-dom@19.1.0)(react@19.1.0)
-      '@tanstack/react-virtual': 3.13.6(react-dom@19.1.0)(react@19.1.0)
+      '@react-aria/focus': 3.20.3(react-dom@19.1.0)(react@19.1.0)
+      '@react-aria/interactions': 3.25.1(react-dom@19.1.0)(react@19.1.0)
+      '@tanstack/react-virtual': 3.13.8(react-dom@19.1.0)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       use-sync-external-store: 1.5.0(react@19.1.0)
@@ -6156,6 +6159,29 @@ packages:
       react-dom: 19.1.0(react@19.1.0)
     dev: false
 
+  /@radix-ui/react-collection@1.1.6(@types/react-dom@19.1.3)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-PbhRFK4lIEw9ADonj48tiYWzkllz81TM7KVYyyMMw2cwHO7D5h4XKEblL8NlaRisTK3QTe6tBEhDccFUryxHBQ==}
+    peerDependencies:
+      '@types/react': ^19.0.2
+      '@types/react-dom': ^19.0.2
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.2(@types/react-dom@19.1.3)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.2(@types/react@19.1.2)(react@19.1.0)
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.3(@types/react@19.1.2)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
   /@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.2)(react@19.1.0):
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
@@ -6244,6 +6270,30 @@ packages:
       '@radix-ui/primitive': 1.1.2
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
       '@radix-ui/react-primitive': 2.1.0(@types/react-dom@19.1.3)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.3(@types/react@19.1.2)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
+  /@radix-ui/react-dismissable-layer@1.1.9(@types/react-dom@19.1.3)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-way197PiTvNp+WBP7svMJasHl+vibhWGQDb6Mgf5mhEWJkgb85z7Lfl9TUdkqpWsf8GRNmoopx9ZxCyDzmgRMQ==}
+    peerDependencies:
+      '@types/react': ^19.0.2
+      '@types/react-dom': ^19.0.2
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.2(@types/react-dom@19.1.3)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.2)(react@19.1.0)
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.1.2)(react@19.1.0)
       '@types/react': 19.1.2
@@ -6382,6 +6432,39 @@ packages:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-remove-scroll: 2.6.3(@types/react@19.1.2)(react@19.1.0)
+    dev: false
+
+  /@radix-ui/react-navigation-menu@1.2.12(@types/react-dom@19.1.3)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-iExvawdu7n6DidDJRU5pMTdi+Z3DaVPN4UZbAGuTs7nJA8P4RvvkEz+XYI2UJjb/Hh23RrH19DakgZNLdaq9Bw==}
+    peerDependencies:
+      '@types/react': ^19.0.2
+      '@types/react-dom': ^19.0.2
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-collection': 1.1.6(@types/react-dom@19.1.3)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.9(@types/react-dom@19.1.3)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.3)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.2(@types/react-dom@19.1.3)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-visually-hidden': 1.2.2(@types/react-dom@19.1.3)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.3(@types/react@19.1.2)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
     dev: false
 
   /@radix-ui/react-popper@1.2.4(@types/react-dom@19.1.3)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
@@ -6713,6 +6796,19 @@ packages:
       react: 19.1.0
     dev: false
 
+  /@radix-ui/react-use-previous@1.1.1(@types/react@19.1.2)(react@19.1.0):
+    resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
+    peerDependencies:
+      '@types/react': ^19.0.2
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 19.1.2
+      react: 19.1.0
+    dev: false
+
   /@radix-ui/react-use-rect@1.1.1(@types/react@19.1.2)(react@19.1.0):
     resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
     peerDependencies:
@@ -6761,35 +6857,55 @@ packages:
       react-dom: 19.1.0(react@19.1.0)
     dev: false
 
+  /@radix-ui/react-visually-hidden@1.2.2(@types/react-dom@19.1.3)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-ORCmRUbNiZIv6uV5mhFrhsIKw4UX/N3syZtyqvry61tbGm4JlgQuSn0hk5TwCARsCjkcnuRkSdCE3xfb+ADHew==}
+    peerDependencies:
+      '@types/react': ^19.0.2
+      '@types/react-dom': ^19.0.2
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.2(@types/react-dom@19.1.3)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.3(@types/react@19.1.2)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
   /@radix-ui/rect@1.1.1:
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
     dev: false
 
-  /@react-aria/focus@3.20.2(react-dom@19.1.0)(react@19.1.0):
-    resolution: {integrity: sha512-Q3rouk/rzoF/3TuH6FzoAIKrl+kzZi9LHmr8S5EqLAOyP9TXIKG34x2j42dZsAhrw7TbF9gA8tBKwnCNH4ZV+Q==}
+  /@react-aria/focus@3.20.3(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-rR5uZUMSY4xLHmpK/I8bP1V6vUNHFo33gTvrvNUsAKKqvMfa7R2nu5A6v97dr5g6tVH6xzpdkPsOJCWh90H2cw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     dependencies:
-      '@react-aria/interactions': 3.25.0(react-dom@19.1.0)(react@19.1.0)
-      '@react-aria/utils': 3.28.2(react-dom@19.1.0)(react@19.1.0)
-      '@react-types/shared': 3.29.0(react@19.1.0)
+      '@react-aria/interactions': 3.25.1(react-dom@19.1.0)(react@19.1.0)
+      '@react-aria/utils': 3.29.0(react-dom@19.1.0)(react@19.1.0)
+      '@react-types/shared': 3.29.1(react@19.1.0)
       '@swc/helpers': 0.5.17
       clsx: 2.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     dev: false
 
-  /@react-aria/interactions@3.25.0(react-dom@19.1.0)(react@19.1.0):
-    resolution: {integrity: sha512-GgIsDLlO8rDU/nFn6DfsbP9rfnzhm8QFjZkB9K9+r+MTSCn7bMntiWQgMM+5O6BiA8d7C7x4zuN4bZtc0RBdXQ==}
+  /@react-aria/interactions@3.25.1(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-ntLrlgqkmZupbbjekz3fE/n3eQH2vhncx8gUp0+N+GttKWevx7jos11JUBjnJwb1RSOPgRUFcrluOqBp0VgcfQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     dependencies:
       '@react-aria/ssr': 3.9.8(react@19.1.0)
-      '@react-aria/utils': 3.28.2(react-dom@19.1.0)(react@19.1.0)
+      '@react-aria/utils': 3.29.0(react-dom@19.1.0)(react@19.1.0)
       '@react-stately/flags': 3.1.1
-      '@react-types/shared': 3.29.0(react@19.1.0)
+      '@react-types/shared': 3.29.1(react@19.1.0)
       '@swc/helpers': 0.5.17
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
@@ -6805,8 +6921,8 @@ packages:
       react: 19.1.0
     dev: false
 
-  /@react-aria/utils@3.28.2(react-dom@19.1.0)(react@19.1.0):
-    resolution: {integrity: sha512-J8CcLbvnQgiBn54eeEvQQbIOfBF3A1QizxMw9P4cl9MkeR03ug7RnjTIdJY/n2p7t59kLeAB3tqiczhcj+Oi5w==}
+  /@react-aria/utils@3.29.0(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-jSOrZimCuT1iKNVlhjIxDkAhgF7HSp3pqyT6qjg/ZoA0wfqCi/okmrMPiWSAKBnkgX93N8GYTLT3CIEO6WZe9Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
@@ -6814,7 +6930,7 @@ packages:
       '@react-aria/ssr': 3.9.8(react@19.1.0)
       '@react-stately/flags': 3.1.1
       '@react-stately/utils': 3.10.6(react@19.1.0)
-      '@react-types/shared': 3.29.0(react@19.1.0)
+      '@react-types/shared': 3.29.1(react@19.1.0)
       '@swc/helpers': 0.5.17
       clsx: 2.1.1
       react: 19.1.0
@@ -7066,8 +7182,8 @@ packages:
       react: 19.1.0
     dev: false
 
-  /@react-types/shared@3.29.0(react@19.1.0):
-    resolution: {integrity: sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==}
+  /@react-types/shared@3.29.1(react@19.1.0):
+    resolution: {integrity: sha512-KtM+cDf2CXoUX439rfEhbnEdAgFZX20UP2A35ypNIawR7/PFFPjQDWyA2EnClCcW/dLWJDEPX2U8+EJff8xqmQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     dependencies:


### PR DESCRIPTION
- Updated MobileMenuButton to use Button component instead of PopoverButton.
- Refactored MobileMenuSection to utilize Accordion components from the new UI library.
- Replaced Popover structure in Nav component with NavigationMenu for improved mobile navigation experience.
- Added NavigationMenu components to handle menu items and triggers.
- Updated package.json to include @radix-ui/react-navigation-menu dependency.