### PR TITLE
feat: notify contact senders of email delivery status

### DIFF
--- a/apps/web/app/api/webhooks/resend/route.test.ts
+++ b/apps/web/app/api/webhooks/resend/route.test.ts
@@ -87,7 +87,7 @@ describe("POST /api/webhooks/resend", () => {
   describe("terminal success event", () => {
     it("sends the delivered notification and clears the inflight entry", async () => {
       mockVerify.mockReturnValue({
-        data: { email_id: EMAIL_ID },
+        data: { email_id: EMAIL_ID, tags: { source: "contact_form" } },
         type: "email.delivered",
       });
 
@@ -116,7 +116,10 @@ describe("POST /api/webhooks/resend", () => {
       "email.complained",
       "email.failed",
     ])("sends the failed notification and clears the inflight entry for %s", async (type) => {
-      mockVerify.mockReturnValue({ data: { email_id: EMAIL_ID }, type });
+      mockVerify.mockReturnValue({
+        data: { email_id: EMAIL_ID, tags: { source: "contact_form" } },
+        type,
+      });
 
       const response = await POST(buildRequest());
 
@@ -148,7 +151,10 @@ describe("POST /api/webhooks/resend", () => {
       "email.delivery_delayed",
       "email.scheduled",
     ])("ignores %s without sending or deleting", async (type) => {
-      mockVerify.mockReturnValue({ data: { email_id: EMAIL_ID }, type });
+      mockVerify.mockReturnValue({
+        data: { email_id: EMAIL_ID, tags: { source: "contact_form" } },
+        type,
+      });
 
       const response = await POST(buildRequest());
 
@@ -161,7 +167,7 @@ describe("POST /api/webhooks/resend", () => {
   describe("edge cases", () => {
     it("ignores events for an unknown email_id", async () => {
       mockVerify.mockReturnValue({
-        data: { email_id: "not-tracked" },
+        data: { email_id: "not-tracked", tags: { source: "contact_form" } },
         type: "email.delivered",
       });
       mockKvGet.mockResolvedValue(null);
@@ -204,7 +210,7 @@ describe("POST /api/webhooks/resend", () => {
 
     it("rejects KV payloads that fail schema validation", async () => {
       mockVerify.mockReturnValue({
-        data: { email_id: EMAIL_ID },
+        data: { email_id: EMAIL_ID, tags: { source: "contact_form" } },
         type: "email.delivered",
       });
       mockKvGet.mockResolvedValue({ fromEmail: "not-an-email" });
@@ -218,7 +224,7 @@ describe("POST /api/webhooks/resend", () => {
 
     it("re-inserts the inflight entry when the follow-up send fails", async () => {
       mockVerify.mockReturnValue({
-        data: { email_id: EMAIL_ID },
+        data: { email_id: EMAIL_ID, tags: { source: "contact_form" } },
         type: "email.delivered",
       });
       mockSend.mockResolvedValue({
@@ -241,9 +247,37 @@ describe("POST /api/webhooks/resend", () => {
       );
     });
 
-    it("skips the send when another handler has already claimed the event", async () => {
+    it("ignores webhook events that aren't tagged as contact-form sends", async () => {
       mockVerify.mockReturnValue({
         data: { email_id: EMAIL_ID },
+        type: "email.delivered",
+      });
+
+      const response = await POST(buildRequest());
+
+      expect(response.status).toBe(200);
+      expect(mockKvGet).not.toHaveBeenCalled();
+      expect(mockKvDel).not.toHaveBeenCalled();
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it("ignores webhook events tagged with a different source", async () => {
+      mockVerify.mockReturnValue({
+        data: { email_id: EMAIL_ID, tags: { source: "bug_report" } },
+        type: "email.delivered",
+      });
+
+      const response = await POST(buildRequest());
+
+      expect(response.status).toBe(200);
+      expect(mockKvGet).not.toHaveBeenCalled();
+      expect(mockKvDel).not.toHaveBeenCalled();
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it("skips the send when another handler has already claimed the event", async () => {
+      mockVerify.mockReturnValue({
+        data: { email_id: EMAIL_ID, tags: { source: "contact_form" } },
         type: "email.delivered",
       });
       mockKvDel.mockResolvedValue(0);
@@ -259,7 +293,7 @@ describe("POST /api/webhooks/resend", () => {
   describe("privacy", () => {
     it("does not expose any officer email address in the outgoing notifications", async () => {
       mockVerify.mockReturnValue({
-        data: { email_id: EMAIL_ID },
+        data: { email_id: EMAIL_ID, tags: { source: "contact_form" } },
         type: "email.bounced",
       });
       mockKvGet.mockResolvedValue({

--- a/apps/web/app/api/webhooks/resend/route.test.ts
+++ b/apps/web/app/api/webhooks/resend/route.test.ts
@@ -262,8 +262,6 @@ describe("POST /api/webhooks/resend", () => {
         data: { email_id: EMAIL_ID },
         type: "email.bounced",
       });
-      // simulate a poisoned KV record that somehow picked up an officer email —
-      // the schema strips unknown keys, so it should never reach the send payload
       mockKvGet.mockResolvedValue({
         ...SAMPLE_CONTACT,
         toEmail: OFFICER_EMAIL,

--- a/apps/web/app/api/webhooks/resend/route.test.ts
+++ b/apps/web/app/api/webhooks/resend/route.test.ts
@@ -1,0 +1,235 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockVerify, mockSend, mockKvGet, mockKvSet, mockKvDel, mockTrack } =
+  vi.hoisted(() => ({
+    mockKvDel: vi.fn(),
+    mockKvGet: vi.fn(),
+    mockKvSet: vi.fn(),
+    mockSend: vi.fn(),
+    mockTrack: vi.fn(),
+    mockVerify: vi.fn(),
+  }));
+
+vi.mock("resend", () => ({
+  Resend: class MockResend {
+    emails = { send: mockSend };
+    webhooks = { verify: mockVerify };
+  },
+}));
+
+vi.mock("@vercel/kv", () => ({
+  kv: { del: mockKvDel, get: mockKvGet, set: mockKvSet },
+}));
+
+vi.mock("@/env", () => ({
+  env: {
+    RESEND_API_KEY: "test-key",
+    RESEND_WEBHOOK_SECRET: "test-secret",
+  },
+}));
+
+vi.mock("@/lib/server/track", () => ({
+  trackServerEvent: mockTrack,
+}));
+
+const { POST } = await import("./route");
+
+const EMAIL_ID = "abc-123";
+const SAMPLE_CONTACT = {
+  fromEmail: "alice@example.com",
+  fromName: "Alice Example",
+  toName: "Bob Officer",
+  toRole: "Captain",
+};
+const OFFICER_EMAIL = "officer-private@example.com";
+
+const DEFAULT_HEADERS = {
+  "svix-id": "msg_1",
+  "svix-signature": "v1,sig",
+  "svix-timestamp": "1",
+};
+
+const buildRequest = (
+  body: unknown = {},
+  headers: Record<string, string> = DEFAULT_HEADERS,
+) =>
+  ({
+    headers: { get: (key: string) => headers[key] ?? null },
+    text: async () => JSON.stringify(body),
+  }) as unknown as NextRequest;
+
+const FAILURE_SUBJECT_PATTERN = /couldn.t deliver/i;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSend.mockResolvedValue({ data: { id: "sent-id" }, error: null });
+  mockKvGet.mockResolvedValue(SAMPLE_CONTACT);
+  mockKvDel.mockResolvedValue(1);
+});
+
+describe("POST /api/webhooks/resend", () => {
+  describe("terminal success event", () => {
+    it("sends the delivered notification and clears the inflight entry", async () => {
+      mockVerify.mockReturnValue({
+        data: { email_id: EMAIL_ID },
+        type: "email.delivered",
+      });
+
+      const response = await POST(buildRequest());
+
+      expect(response.status).toBe(200);
+      expect(mockSend).toHaveBeenCalledTimes(1);
+
+      const args = mockSend.mock.calls[0][0];
+
+      expect(args.to).toContain(SAMPLE_CONTACT.fromEmail);
+      expect(args.subject).toContain("delivered");
+      expect(args.subject).toContain(SAMPLE_CONTACT.toRole);
+      expect(mockKvDel).toHaveBeenCalledWith(`contact:inflight:${EMAIL_ID}`);
+    });
+  });
+
+  describe("terminal failure events", () => {
+    it.each([
+      "email.bounced",
+      "email.complained",
+      "email.failed",
+      "email.canceled",
+    ])("sends the failed notification and clears the inflight entry for %s", async (type) => {
+      mockVerify.mockReturnValue({ data: { email_id: EMAIL_ID }, type });
+
+      const response = await POST(buildRequest());
+
+      expect(response.status).toBe(200);
+      expect(mockSend).toHaveBeenCalledTimes(1);
+
+      const args = mockSend.mock.calls[0][0];
+
+      expect(args.to).toContain(SAMPLE_CONTACT.fromEmail);
+      expect(args.subject).toMatch(FAILURE_SUBJECT_PATTERN);
+      expect(args.text).toContain("enquiries@sudburyrowingclub.org.uk");
+      expect(mockKvDel).toHaveBeenCalledWith(`contact:inflight:${EMAIL_ID}`);
+    });
+  });
+
+  describe("non-terminal events", () => {
+    it.each([
+      "email.sent",
+      "email.opened",
+      "email.clicked",
+      "email.delivery_delayed",
+      "email.scheduled",
+    ])("ignores %s without sending or deleting", async (type) => {
+      mockVerify.mockReturnValue({ data: { email_id: EMAIL_ID }, type });
+
+      const response = await POST(buildRequest());
+
+      expect(response.status).toBe(200);
+      expect(mockSend).not.toHaveBeenCalled();
+      expect(mockKvDel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("ignores events for an unknown email_id", async () => {
+      mockVerify.mockReturnValue({
+        data: { email_id: "not-tracked" },
+        type: "email.delivered",
+      });
+      mockKvGet.mockResolvedValue(null);
+
+      const response = await POST(buildRequest());
+
+      expect(response.status).toBe(200);
+      expect(mockSend).not.toHaveBeenCalled();
+      expect(mockKvDel).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when Svix headers are missing", async () => {
+      const response = await POST(buildRequest({}, {}));
+
+      expect(response.status).toBe(400);
+      expect(mockVerify).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when signature verification throws", async () => {
+      mockVerify.mockImplementation(() => {
+        throw new Error("invalid signature");
+      });
+
+      const response = await POST(buildRequest());
+
+      expect(response.status).toBe(400);
+      expect(mockSend).not.toHaveBeenCalled();
+      expect(mockKvDel).not.toHaveBeenCalled();
+    });
+
+    it("ignores verified payloads whose email_id is missing", async () => {
+      mockVerify.mockReturnValue({ data: {}, type: "email.delivered" });
+
+      const response = await POST(buildRequest());
+
+      expect(response.status).toBe(200);
+      expect(mockSend).not.toHaveBeenCalled();
+      expect(mockKvDel).not.toHaveBeenCalled();
+    });
+
+    it("rejects KV payloads that fail schema validation", async () => {
+      mockVerify.mockReturnValue({
+        data: { email_id: EMAIL_ID },
+        type: "email.delivered",
+      });
+      mockKvGet.mockResolvedValue({ fromEmail: "not-an-email" });
+
+      const response = await POST(buildRequest());
+
+      expect(response.status).toBe(200);
+      expect(mockSend).not.toHaveBeenCalled();
+      expect(mockKvDel).not.toHaveBeenCalled();
+    });
+
+    it("does not delete the inflight entry when the follow-up send fails", async () => {
+      mockVerify.mockReturnValue({
+        data: { email_id: EMAIL_ID },
+        type: "email.delivered",
+      });
+      mockSend.mockResolvedValue({
+        data: null,
+        error: { message: "boom", name: "ApiError" },
+      });
+
+      const response = await POST(buildRequest());
+
+      expect(response.status).toBe(500);
+      expect(mockKvDel).not.toHaveBeenCalled();
+      expect(mockTrack).toHaveBeenCalledWith(
+        "contact_form_status_notification_failure",
+        expect.objectContaining({ event_type: "email.delivered" }),
+      );
+    });
+  });
+
+  describe("privacy", () => {
+    it("does not expose any officer email address in the outgoing notifications", async () => {
+      mockVerify.mockReturnValue({
+        data: { email_id: EMAIL_ID },
+        type: "email.bounced",
+      });
+      // simulate a poisoned KV record that somehow picked up an officer email —
+      // the schema strips unknown keys, so it should never reach the send payload
+      mockKvGet.mockResolvedValue({
+        ...SAMPLE_CONTACT,
+        toEmail: OFFICER_EMAIL,
+      });
+
+      const response = await POST(buildRequest());
+
+      expect(response.status).toBe(200);
+
+      const serialized = JSON.stringify(mockSend.mock.calls[0][0]);
+
+      expect(serialized).not.toContain(OFFICER_EMAIL);
+    });
+  });
+});

--- a/apps/web/app/api/webhooks/resend/route.test.ts
+++ b/apps/web/app/api/webhooks/resend/route.test.ts
@@ -100,7 +100,7 @@ describe("POST /api/webhooks/resend", () => {
 
       expect(args.to).toContain(SAMPLE_CONTACT.fromEmail);
       expect(args.subject).toContain("delivered");
-      expect(args.subject).toContain(SAMPLE_CONTACT.toRole);
+      expect(args.subject).toContain(SAMPLE_CONTACT.toName);
       expect(args.react.__template).toBe("delivered");
       expect(args.react.__props.message).toBe(SAMPLE_CONTACT.message);
       expect(args.react.__props.fromName).toBe(SAMPLE_CONTACT.fromName);
@@ -127,6 +127,7 @@ describe("POST /api/webhooks/resend", () => {
 
       expect(args.to).toContain(SAMPLE_CONTACT.fromEmail);
       expect(args.subject).toMatch(FAILURE_SUBJECT_PATTERN);
+      expect(args.subject).toContain(SAMPLE_CONTACT.toName);
       expect(args.text).toContain("enquiries@sudburyrowingclub.org.uk");
       expect(args.react.__template).toBe("failed");
       expect(args.react.__props.message).toBe(SAMPLE_CONTACT.message);

--- a/apps/web/app/api/webhooks/resend/route.test.ts
+++ b/apps/web/app/api/webhooks/resend/route.test.ts
@@ -33,12 +33,27 @@ vi.mock("@/lib/server/track", () => ({
   trackServerEvent: mockTrack,
 }));
 
+vi.mock("emails/contact-form-delivered", () => ({
+  ContactFormDeliveredEmail: (props: Record<string, unknown>) => ({
+    __props: props,
+    __template: "delivered",
+  }),
+}));
+
+vi.mock("emails/contact-form-failed", () => ({
+  ContactFormFailedEmail: (props: Record<string, unknown>) => ({
+    __props: props,
+    __template: "failed",
+  }),
+}));
+
 const { POST } = await import("./route");
 
 const EMAIL_ID = "abc-123";
 const SAMPLE_CONTACT = {
   fromEmail: "alice@example.com",
   fromName: "Alice Example",
+  message: "Please sign me up for trial sessions.",
   toName: "Bob Officer",
   toRole: "Captain",
 };
@@ -86,6 +101,11 @@ describe("POST /api/webhooks/resend", () => {
       expect(args.to).toContain(SAMPLE_CONTACT.fromEmail);
       expect(args.subject).toContain("delivered");
       expect(args.subject).toContain(SAMPLE_CONTACT.toRole);
+      expect(args.react.__template).toBe("delivered");
+      expect(args.react.__props.message).toBe(SAMPLE_CONTACT.message);
+      expect(args.react.__props.fromName).toBe(SAMPLE_CONTACT.fromName);
+      expect(args.react.__props.toName).toBe(SAMPLE_CONTACT.toName);
+      expect(args.react.__props.toRole).toBe(SAMPLE_CONTACT.toRole);
       expect(mockKvDel).toHaveBeenCalledWith(`contact:inflight:${EMAIL_ID}`);
     });
   });
@@ -108,6 +128,13 @@ describe("POST /api/webhooks/resend", () => {
       expect(args.to).toContain(SAMPLE_CONTACT.fromEmail);
       expect(args.subject).toMatch(FAILURE_SUBJECT_PATTERN);
       expect(args.text).toContain("enquiries@sudburyrowingclub.org.uk");
+      expect(args.react.__template).toBe("failed");
+      expect(args.react.__props.message).toBe(SAMPLE_CONTACT.message);
+      expect(args.react.__props.fromName).toBe(SAMPLE_CONTACT.fromName);
+      expect(args.react.__props.toRole).toBe(SAMPLE_CONTACT.toRole);
+      expect(args.react.__props.fallbackEmail).toBe(
+        "enquiries@sudburyrowingclub.org.uk",
+      );
       expect(mockKvDel).toHaveBeenCalledWith(`contact:inflight:${EMAIL_ID}`);
     });
   });
@@ -188,7 +215,7 @@ describe("POST /api/webhooks/resend", () => {
       expect(mockKvDel).not.toHaveBeenCalled();
     });
 
-    it("does not delete the inflight entry when the follow-up send fails", async () => {
+    it("re-inserts the inflight entry when the follow-up send fails", async () => {
       mockVerify.mockReturnValue({
         data: { email_id: EMAIL_ID },
         type: "email.delivered",
@@ -201,11 +228,30 @@ describe("POST /api/webhooks/resend", () => {
       const response = await POST(buildRequest());
 
       expect(response.status).toBe(500);
-      expect(mockKvDel).not.toHaveBeenCalled();
+      expect(mockKvDel).toHaveBeenCalledWith(`contact:inflight:${EMAIL_ID}`);
+      expect(mockKvSet).toHaveBeenCalledWith(
+        `contact:inflight:${EMAIL_ID}`,
+        SAMPLE_CONTACT,
+        expect.objectContaining({ ex: expect.any(Number) }),
+      );
       expect(mockTrack).toHaveBeenCalledWith(
         "contact_form_status_notification_failure",
         expect.objectContaining({ event_type: "email.delivered" }),
       );
+    });
+
+    it("skips the send when another handler has already claimed the event", async () => {
+      mockVerify.mockReturnValue({
+        data: { email_id: EMAIL_ID },
+        type: "email.delivered",
+      });
+      mockKvDel.mockResolvedValue(0);
+
+      const response = await POST(buildRequest());
+
+      expect(response.status).toBe(200);
+      expect(mockSend).not.toHaveBeenCalled();
+      expect(mockKvSet).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/app/api/webhooks/resend/route.test.ts
+++ b/apps/web/app/api/webhooks/resend/route.test.ts
@@ -95,7 +95,6 @@ describe("POST /api/webhooks/resend", () => {
       "email.bounced",
       "email.complained",
       "email.failed",
-      "email.canceled",
     ])("sends the failed notification and clears the inflight entry for %s", async (type) => {
       mockVerify.mockReturnValue({ data: { email_id: EMAIL_ID }, type });
 

--- a/apps/web/app/api/webhooks/resend/route.ts
+++ b/apps/web/app/api/webhooks/resend/route.ts
@@ -1,0 +1,147 @@
+import { ContactFormDeliveredEmail } from "emails/contact-form-delivered";
+import { ContactFormFailedEmail } from "emails/contact-form-failed";
+import { type NextRequest, NextResponse } from "next/server";
+import { tryit } from "radashi";
+import { Resend } from "resend";
+import { z } from "zod";
+import { env } from "@/env";
+import { EMAIL, SENDER } from "@/lib/constants";
+import {
+  deleteInflightContact,
+  type InflightContact,
+  readInflightContact,
+} from "@/lib/inflight-contact";
+import { trackServerEvent } from "@/lib/server/track";
+
+const ResendEventSchema = z.object({
+  data: z.object({
+    email_id: z.string().optional(),
+  }),
+  type: z.string(),
+});
+
+const resend = new Resend(env.RESEND_API_KEY);
+
+const formatName = (email: string, name: string) => {
+  if (name) return `${name} <${email}>`;
+
+  return email;
+};
+
+const DELIVERED_EVENTS = new Set(["email.delivered"]);
+const FAILED_EVENTS = new Set([
+  "email.bounced",
+  "email.complained",
+  "email.failed",
+  "email.canceled",
+]);
+
+const sendDeliveredNotification = async (
+  contact: InflightContact,
+): Promise<{ error?: string }> => {
+  const { data, error } = await resend.emails.send({
+    from: formatName(SENDER.email, SENDER.name),
+    react: ContactFormDeliveredEmail({
+      fromName: contact.fromName,
+      toName: contact.toName,
+      toRole: contact.toRole,
+    }),
+    subject: `We’ve delivered your message to ${contact.toRole}`,
+    text: `We’ve delivered your message to ${contact.toName} (${contact.toRole}). They’ll reply to you directly.`,
+    to: formatName(contact.fromEmail, contact.fromName),
+  });
+
+  if (error) return { error: error.message };
+  if (!data?.id) return { error: "No message ID returned" };
+
+  return {};
+};
+
+const sendFailedNotification = async (
+  contact: InflightContact,
+): Promise<{ error?: string }> => {
+  const { data, error } = await resend.emails.send({
+    from: formatName(SENDER.email, SENDER.name),
+    react: ContactFormFailedEmail({
+      fallbackEmail: EMAIL,
+      fromName: contact.fromName,
+      toRole: contact.toRole,
+    }),
+    subject: "We couldn’t deliver your message to Sudbury Rowing Club",
+    text: `We couldn’t deliver your message to the ${contact.toRole}. Please email ${EMAIL} directly and someone will pass it on.`,
+    to: formatName(contact.fromEmail, contact.fromName),
+  });
+
+  if (error) return { error: error.message };
+  if (!data?.id) return { error: "No message ID returned" };
+
+  return {};
+};
+
+export async function POST(req: NextRequest) {
+  const payload = await req.text();
+
+  const id = req.headers.get("svix-id");
+  const timestamp = req.headers.get("svix-timestamp");
+  const signature = req.headers.get("svix-signature");
+
+  if (!(id && timestamp && signature)) {
+    return new NextResponse("Missing Svix headers", { status: 400 });
+  }
+
+  const [verifyError, verified] = await tryit(async () =>
+    resend.webhooks.verify({
+      headers: { id, signature, timestamp },
+      payload,
+      webhookSecret: env.RESEND_WEBHOOK_SECRET,
+    }),
+  )();
+
+  if (verifyError || !verified) {
+    return new NextResponse("Invalid signature", { status: 400 });
+  }
+
+  const parsed = ResendEventSchema.safeParse(verified);
+
+  if (!parsed.success) {
+    return NextResponse.json({ ignored: "unparseable" }, { status: 200 });
+  }
+
+  const { type: eventType, data } = parsed.data;
+  const emailId = data.email_id;
+
+  if (!emailId) {
+    return NextResponse.json({ ignored: "no email_id" }, { status: 200 });
+  }
+
+  const isDelivered = DELIVERED_EVENTS.has(eventType);
+  const isFailed = FAILED_EVENTS.has(eventType);
+
+  if (!(isDelivered || isFailed)) {
+    return NextResponse.json({ ignored: eventType }, { status: 200 });
+  }
+
+  const contact = await readInflightContact(emailId);
+
+  if (!contact) {
+    return NextResponse.json({ ignored: "not tracked" }, { status: 200 });
+  }
+
+  const { error: sendError } = isDelivered
+    ? await sendDeliveredNotification(contact)
+    : await sendFailedNotification(contact);
+
+  if (sendError) {
+    trackServerEvent("contact_form_status_notification_failure", {
+      error_message: sendError,
+      event_type: eventType,
+      service: "resend",
+    });
+
+    return new NextResponse("Notification send failed", { status: 500 });
+  }
+
+  await deleteInflightContact(emailId);
+
+  return NextResponse.json({ handled: eventType }, { status: 200 });
+}

--- a/apps/web/app/api/webhooks/resend/route.ts
+++ b/apps/web/app/api/webhooks/resend/route.ts
@@ -39,7 +39,7 @@ const FAILED_EVENTS = new Set<WebhookEvent>([
 const sendDeliveredNotification = async (
   contact: InflightContact,
 ): Promise<{ error?: string }> => {
-  const { data, error } = await resend.emails.send({
+  const { error } = await resend.emails.send({
     from: formatName(SENDER.email, SENDER.name),
     react: ContactFormDeliveredEmail({
       fromName: contact.fromName,
@@ -53,7 +53,6 @@ const sendDeliveredNotification = async (
   });
 
   if (error) return { error: error.message };
-  if (!data?.id) return { error: "No message ID returned" };
 
   return {};
 };
@@ -61,7 +60,7 @@ const sendDeliveredNotification = async (
 const sendFailedNotification = async (
   contact: InflightContact,
 ): Promise<{ error?: string }> => {
-  const { data, error } = await resend.emails.send({
+  const { error } = await resend.emails.send({
     from: formatName(SENDER.email, SENDER.name),
     react: ContactFormFailedEmail({
       fallbackEmail: EMAIL,
@@ -75,7 +74,6 @@ const sendFailedNotification = async (
   });
 
   if (error) return { error: error.message };
-  if (!data?.id) return { error: "No message ID returned" };
 
   return {};
 };

--- a/apps/web/app/api/webhooks/resend/route.ts
+++ b/apps/web/app/api/webhooks/resend/route.ts
@@ -2,7 +2,7 @@ import { ContactFormDeliveredEmail } from "emails/contact-form-delivered";
 import { ContactFormFailedEmail } from "emails/contact-form-failed";
 import { type NextRequest, NextResponse } from "next/server";
 import { tryit } from "radashi";
-import { Resend } from "resend";
+import { Resend, type WebhookEvent } from "resend";
 import { z } from "zod";
 import { env } from "@/env";
 import { EMAIL, SENDER } from "@/lib/constants";
@@ -28,12 +28,11 @@ const formatName = (email: string, name: string) => {
   return email;
 };
 
-const DELIVERED_EVENTS = new Set(["email.delivered"]);
-const FAILED_EVENTS = new Set([
+const DELIVERED_EVENTS = new Set<WebhookEvent>(["email.delivered"]);
+const FAILED_EVENTS = new Set<WebhookEvent>([
   "email.bounced",
   "email.complained",
   "email.failed",
-  "email.canceled",
 ]);
 
 const sendDeliveredNotification = async (
@@ -114,8 +113,8 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ ignored: "no email_id" }, { status: 200 });
   }
 
-  const isDelivered = DELIVERED_EVENTS.has(eventType);
-  const isFailed = FAILED_EVENTS.has(eventType);
+  const isDelivered = DELIVERED_EVENTS.has(eventType as WebhookEvent);
+  const isFailed = FAILED_EVENTS.has(eventType as WebhookEvent);
 
   if (!(isDelivered || isFailed)) {
     return NextResponse.json({ ignored: eventType }, { status: 200 });

--- a/apps/web/app/api/webhooks/resend/route.ts
+++ b/apps/web/app/api/webhooks/resend/route.ts
@@ -7,9 +7,10 @@ import { z } from "zod";
 import { env } from "@/env";
 import { EMAIL, SENDER } from "@/lib/constants";
 import {
-  deleteInflightContact,
+  claimInflightContact,
   type InflightContact,
   readInflightContact,
+  storeInflightContact,
 } from "@/lib/inflight-contact";
 import { trackServerEvent } from "@/lib/server/track";
 
@@ -42,6 +43,7 @@ const sendDeliveredNotification = async (
     from: formatName(SENDER.email, SENDER.name),
     react: ContactFormDeliveredEmail({
       fromName: contact.fromName,
+      message: contact.message,
       toName: contact.toName,
       toRole: contact.toRole,
     }),
@@ -64,6 +66,7 @@ const sendFailedNotification = async (
     react: ContactFormFailedEmail({
       fallbackEmail: EMAIL,
       fromName: contact.fromName,
+      message: contact.message,
       toRole: contact.toRole,
     }),
     subject: "We couldn’t deliver your message to Sudbury Rowing Club",
@@ -126,11 +129,19 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ ignored: "not tracked" }, { status: 200 });
   }
 
+  const claimed = await claimInflightContact(emailId);
+
+  if (!claimed) {
+    return NextResponse.json({ ignored: "already claimed" }, { status: 200 });
+  }
+
   const { error: sendError } = isDelivered
     ? await sendDeliveredNotification(contact)
     : await sendFailedNotification(contact);
 
   if (sendError) {
+    await tryit(storeInflightContact)(emailId, contact);
+
     trackServerEvent("contact_form_status_notification_failure", {
       error_message: sendError,
       event_type: eventType,
@@ -139,8 +150,6 @@ export async function POST(req: NextRequest) {
 
     return new NextResponse("Notification send failed", { status: 500 });
   }
-
-  await deleteInflightContact(emailId);
 
   return NextResponse.json({ handled: eventType }, { status: 200 });
 }

--- a/apps/web/app/api/webhooks/resend/route.ts
+++ b/apps/web/app/api/webhooks/resend/route.ts
@@ -5,7 +5,7 @@ import { tryit } from "radashi";
 import { Resend, type WebhookEvent } from "resend";
 import { z } from "zod";
 import { env } from "@/env";
-import { EMAIL, SENDER } from "@/lib/constants";
+import { CONTACT_FORM_TAG, EMAIL, SENDER } from "@/lib/constants";
 import {
   claimInflightContact,
   type InflightContact,
@@ -17,6 +17,7 @@ import { trackServerEvent } from "@/lib/server/track";
 const ResendEventSchema = z.object({
   data: z.object({
     email_id: z.string().optional(),
+    tags: z.record(z.string(), z.string()).optional(),
   }),
   type: z.string(),
 });
@@ -119,6 +120,10 @@ export async function POST(req: NextRequest) {
 
   if (!(isDelivered || isFailed)) {
     return NextResponse.json({ ignored: eventType }, { status: 200 });
+  }
+
+  if (data.tags?.[CONTACT_FORM_TAG.name] !== CONTACT_FORM_TAG.value) {
+    return NextResponse.json({ ignored: "untagged" }, { status: 200 });
   }
 
   const contact = await readInflightContact(emailId);

--- a/apps/web/app/api/webhooks/resend/route.ts
+++ b/apps/web/app/api/webhooks/resend/route.ts
@@ -47,7 +47,7 @@ const sendDeliveredNotification = async (
       toName: contact.toName,
       toRole: contact.toRole,
     }),
-    subject: `We’ve delivered your message to ${contact.toRole}`,
+    subject: `We’ve delivered your message to ${contact.toName}`,
     text: `We’ve delivered your message to ${contact.toName} (${contact.toRole}). They’ll reply to you directly.`,
     to: formatName(contact.fromEmail, contact.fromName),
   });
@@ -69,8 +69,8 @@ const sendFailedNotification = async (
       message: contact.message,
       toRole: contact.toRole,
     }),
-    subject: "We couldn’t deliver your message to Sudbury Rowing Club",
-    text: `We couldn’t deliver your message to the ${contact.toRole}. Please email ${EMAIL} directly and someone will pass it on.`,
+    subject: `We couldn’t deliver your message to ${contact.toName}`,
+    text: `We couldn’t deliver your message to ${contact.toName}. Please email ${EMAIL} directly and someone will pass it on.`,
     to: formatName(contact.fromEmail, contact.fromName),
   });
 

--- a/apps/web/emails/contact-form-delivered.tsx
+++ b/apps/web/emails/contact-form-delivered.tsx
@@ -1,0 +1,108 @@
+import {
+  Body,
+  Column,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Link,
+  Markdown,
+  Preview,
+  Row,
+  Section,
+  Tailwind,
+  Text,
+} from "@react-email/components";
+
+interface ContactFormDeliveredEmailProps {
+  fromName?: string;
+  message?: string;
+  toName?: string;
+  toRole?: string;
+}
+
+const Label = ({ children }: { children: React.ReactNode }) => (
+  <span className="my-2 block font-medium text-gray-500 text-sm">
+    {children}
+  </span>
+);
+
+const Value = ({ children }: { children: React.ReactNode }) => (
+  <span className="block font-medium text-gray-900 text-sm">{children}</span>
+);
+
+const RightArrow = () => <span className="text-gray-400">&rarr;</span>;
+const Quote = ({ value }: { value: string }) => (
+  <>
+    <span className="text-gray-400">&lsquo;</span>
+    {value}
+    <span className="text-gray-400">&rsquo;</span>
+  </>
+);
+
+export const ContactFormDeliveredEmail = ({
+  toName = "Per Person",
+  toRole = "Chairperson",
+  fromName = "From Person",
+  message = "Hello, this is a message\n\nIt has come to my attention that you are a person. This is a good thing, as I am also a person. We should meet up and do person things together.\n\nRegards,\n\nPerson",
+}: ContactFormDeliveredEmailProps) => (
+  <Html>
+    <Head />
+
+    <Preview>We’ve delivered your message to Sudbury Rowing Club</Preview>
+
+    <Tailwind>
+      <Body className="font-sans">
+        <Container>
+          <Heading className="font-normal text-black text-lg">
+            We’ve delivered your message, {fromName}
+          </Heading>
+
+          <Text className="text-gray-700 text-sm">
+            {toName} will reply to you directly.
+          </Text>
+
+          <Section>
+            <Text>
+              <Label>Delivered to:</Label>
+              <Value>
+                <Quote value={toRole} /> <RightArrow /> {toName}
+              </Value>
+            </Text>
+
+            <Row>
+              <Column>
+                <Label>Your message:</Label>
+                <div className="m-0 text-gray-900 text-sm">
+                  <Markdown>{message}</Markdown>
+                </div>
+              </Column>
+            </Row>
+          </Section>
+
+          <Section className="mt-8">
+            <Hr className="border-gray-200" />
+            <Text className="font-medium text-gray-600 text-xs">
+              You’re receiving this because you sent a message using the{" "}
+              <Link
+                className="text-blue-500"
+                href="https://sudburyrowingclub.org.uk/contact"
+              >
+                contact form
+              </Link>{" "}
+              on the Sudbury Rowing Club website. If you didn’t send this,
+              please{" "}
+              <Link className="text-blue-500" href="mailto:will@willkerry.com">
+                contact Will
+              </Link>
+              .
+            </Text>
+          </Section>
+        </Container>
+      </Body>
+    </Tailwind>
+  </Html>
+);
+
+export default ContactFormDeliveredEmail;

--- a/apps/web/emails/contact-form-delivered.tsx
+++ b/apps/web/emails/contact-form-delivered.tsx
@@ -50,7 +50,7 @@ export const ContactFormDeliveredEmail = ({
   <Html>
     <Head />
 
-    <Preview>We’ve delivered your message to Sudbury Rowing Club</Preview>
+    <Preview>{toName} will reply to you directly.</Preview>
 
     <Tailwind>
       <Body className="font-sans">

--- a/apps/web/emails/contact-form-failed.tsx
+++ b/apps/web/emails/contact-form-failed.tsx
@@ -37,7 +37,7 @@ export const ContactFormFailedEmail = ({
   <Html>
     <Head />
 
-    <Preview>We couldn’t deliver your message</Preview>
+    <Preview>Don’t expect a reply. Here’s what to do next.</Preview>
 
     <Tailwind>
       <Body className="font-sans">

--- a/apps/web/emails/contact-form-failed.tsx
+++ b/apps/web/emails/contact-form-failed.tsx
@@ -1,0 +1,97 @@
+import {
+  Body,
+  Column,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Link,
+  Markdown,
+  Preview,
+  Row,
+  Section,
+  Tailwind,
+  Text,
+} from "@react-email/components";
+
+interface ContactFormFailedEmailProps {
+  fallbackEmail?: string;
+  fromName?: string;
+  message?: string;
+  toRole?: string;
+}
+
+const Label = ({ children }: { children: React.ReactNode }) => (
+  <span className="my-2 block font-medium text-gray-500 text-sm">
+    {children}
+  </span>
+);
+
+export const ContactFormFailedEmail = ({
+  fallbackEmail = "enquiries@sudburyrowingclub.org.uk",
+  fromName = "From Person",
+  toRole = "Chairperson",
+  message = "Hello, this is a message\n\nIt has come to my attention that you are a person. This is a good thing, as I am also a person. We should meet up and do person things together.\n\nRegards,\n\nPerson",
+}: ContactFormFailedEmailProps) => (
+  <Html>
+    <Head />
+
+    <Preview>We couldn’t deliver your message</Preview>
+
+    <Tailwind>
+      <Body className="font-sans">
+        <Container>
+          <Heading className="font-normal text-black text-lg">
+            We couldn’t deliver your message, {fromName}
+          </Heading>
+
+          <Text className="text-gray-700 text-sm">
+            Your message to the <em>{toRole}</em> didn’t reach them, so don’t
+            expect a reply.
+          </Text>
+
+          <Text className="text-gray-700 text-sm">
+            Please email{" "}
+            <Link className="text-blue-500" href={`mailto:${fallbackEmail}`}>
+              {fallbackEmail}
+            </Link>{" "}
+            directly. Someone at the club will read it and pass it on.
+          </Text>
+
+          <Section>
+            <Row>
+              <Column>
+                <Label>Your message:</Label>
+                <div className="m-0 text-gray-900 text-sm">
+                  <Markdown>{message}</Markdown>
+                </div>
+              </Column>
+            </Row>
+          </Section>
+
+          <Section className="mt-8">
+            <Hr className="border-gray-200" />
+            <Text className="font-medium text-gray-600 text-xs">
+              You’re receiving this because you sent a message using the{" "}
+              <Link
+                className="text-blue-500"
+                href="https://sudburyrowingclub.org.uk/contact"
+              >
+                contact form
+              </Link>{" "}
+              on the Sudbury Rowing Club website. If you didn’t send this,
+              please{" "}
+              <Link className="text-blue-500" href="mailto:will@willkerry.com">
+                contact Will
+              </Link>
+              .
+            </Text>
+          </Section>
+        </Container>
+      </Body>
+    </Tailwind>
+  </Html>
+);
+
+export default ContactFormFailedEmail;

--- a/apps/web/env.ts
+++ b/apps/web/env.ts
@@ -32,6 +32,7 @@ export const env = createEnv({
     NODE_ENV: process.env.NODE_ENV,
     REDIRECT_SECRET: process.env.REDIRECT_SECRET,
     RESEND_API_KEY: process.env.RESEND_API_KEY,
+    RESEND_WEBHOOK_SECRET: process.env.RESEND_WEBHOOK_SECRET,
     TURNSTILE_SECRET_KEY: process.env.TURNSTILE_SECRET_KEY,
     VERCEL_ENV: process.env.VERCEL_ENV,
   },
@@ -40,6 +41,7 @@ export const env = createEnv({
     BUG_RECIPIENT_EMAIL: z.string(),
     REDIRECT_SECRET: z.string().min(32),
     RESEND_API_KEY: z.string().min(1),
+    RESEND_WEBHOOK_SECRET: z.string().min(1),
     TURNSTILE_SECRET_KEY: z.string().min(1),
   },
   shared: {

--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -24,6 +24,11 @@ export const SENDER = {
   name: "Sudbury Rowing Club",
 };
 
+export const CONTACT_FORM_TAG = {
+  name: "source",
+  value: "contact_form",
+} as const;
+
 export const SUPPORTED_SOCIALS = ["instagram", "facebook"] as const;
 
 export const SOCIALS: Record<

--- a/apps/web/lib/inflight-contact.ts
+++ b/apps/web/lib/inflight-contact.ts
@@ -1,0 +1,39 @@
+import { kv } from "@vercel/kv";
+import { z } from "zod";
+
+const KEY_PREFIX = "contact:inflight:";
+const TTL_SECONDS = 60 * 60 * 72;
+
+export const InflightContactSchema = z.object({
+  fromEmail: z.email(),
+  fromName: z.string().min(1),
+  toName: z.string().min(1),
+  toRole: z.string().min(1),
+});
+
+export type InflightContact = z.infer<typeof InflightContactSchema>;
+
+const key = (messageId: string) => `${KEY_PREFIX}${messageId}`;
+
+export const storeInflightContact = async (
+  messageId: string,
+  value: InflightContact,
+) => {
+  await kv.set(key(messageId), value, { ex: TTL_SECONDS });
+};
+
+export const readInflightContact = async (messageId: string) => {
+  const value = await kv.get(key(messageId));
+
+  if (!value) return null;
+
+  const parsed = InflightContactSchema.safeParse(value);
+
+  if (!parsed.success) return null;
+
+  return parsed.data;
+};
+
+export const deleteInflightContact = async (messageId: string) => {
+  await kv.del(key(messageId));
+};

--- a/apps/web/lib/inflight-contact.ts
+++ b/apps/web/lib/inflight-contact.ts
@@ -7,6 +7,7 @@ const TTL_SECONDS = 60 * 60 * 72;
 export const InflightContactSchema = z.object({
   fromEmail: z.email(),
   fromName: z.string().min(1),
+  message: z.string().min(1),
   toName: z.string().min(1),
   toRole: z.string().min(1),
 });
@@ -34,6 +35,8 @@ export const readInflightContact = async (messageId: string) => {
   return parsed.data;
 };
 
-export const deleteInflightContact = async (messageId: string) => {
-  await kv.del(key(messageId));
+export const claimInflightContact = async (messageId: string) => {
+  const deleted = await kv.del(key(messageId));
+
+  return deleted === 1;
 };

--- a/apps/web/lib/trpc/routers/comms.ts
+++ b/apps/web/lib/trpc/routers/comms.ts
@@ -152,6 +152,7 @@ export const commsRouter = router({
       }
 
       const { name: toName, email: toEmail, role: toRole } = officer;
+      const sanitizedMessage = DOMPurify.sanitize(input.message);
 
       const createEmailResponse = await resend.emails.send({
         from: formatName(SENDER.email, SENDER.name),
@@ -161,11 +162,11 @@ export const commsRouter = router({
           toRole,
           fromEmail: input.email,
           fromName: input.name,
-          message: DOMPurify.sanitize(input.message),
+          message: sanitizedMessage,
         }),
         replyTo: formatName(input.email, input.name),
         subject: `${input.name} via SRC Contact`,
-        text: DOMPurify.sanitize(input.message),
+        text: sanitizedMessage,
         to: formatName(toEmail, toName),
       });
 
@@ -188,6 +189,7 @@ export const commsRouter = router({
         const [storeError] = await tryit(storeInflightContact)(messageId, {
           fromEmail: input.email,
           fromName: input.name,
+          message: sanitizedMessage,
           toName,
           toRole,
         });

--- a/apps/web/lib/trpc/routers/comms.ts
+++ b/apps/web/lib/trpc/routers/comms.ts
@@ -10,6 +10,7 @@ import { env } from "@/env";
 import { checkHeadersForSpam } from "@/lib/akismet";
 import { SENDER } from "@/lib/constants";
 import { getOfficer } from "@/lib/get-officer";
+import { storeInflightContact } from "@/lib/inflight-contact";
 import { trackServerEvent } from "@/lib/server/track";
 // import { checkHeadersForTurnstileToken } from "@/lib/turnstile";
 import { rateLimitedProcedure, router } from "../init";
@@ -181,8 +182,26 @@ export const commsRouter = router({
         });
       }
 
+      const messageId = createEmailResponse.data?.id ?? null;
+
+      if (messageId) {
+        const [storeError] = await tryit(storeInflightContact)(messageId, {
+          fromEmail: input.email,
+          fromName: input.name,
+          toName,
+          toRole,
+        });
+
+        if (storeError) {
+          trackServerEvent("contact_form_inflight_store_failure", {
+            error_message: storeError.message,
+            error_name: storeError.name,
+          });
+        }
+      }
+
       return {
-        messageId: createEmailResponse.data?.id ?? null,
+        messageId,
       };
     }),
 });

--- a/apps/web/lib/trpc/routers/comms.ts
+++ b/apps/web/lib/trpc/routers/comms.ts
@@ -8,7 +8,7 @@ import { BugReportSchema } from "@/app/bugs/BugReportSchema";
 import { MessageSchema } from "@/components/contact/Message";
 import { env } from "@/env";
 import { checkHeadersForSpam } from "@/lib/akismet";
-import { SENDER } from "@/lib/constants";
+import { CONTACT_FORM_TAG, SENDER } from "@/lib/constants";
 import { getOfficer } from "@/lib/get-officer";
 import { storeInflightContact } from "@/lib/inflight-contact";
 import { trackServerEvent } from "@/lib/server/track";
@@ -166,6 +166,7 @@ export const commsRouter = router({
         }),
         replyTo: formatName(input.email, input.name),
         subject: `${input.name} via SRC Contact`,
+        tags: [CONTACT_FORM_TAG],
         text: sanitizedMessage,
         to: formatName(toEmail, toName),
       });

--- a/turbo.json
+++ b/turbo.json
@@ -14,6 +14,7 @@
         "NEXT_PUBLIC_*",
         "REDIRECT_SECRET",
         "RESEND_API_KEY",
+        "RESEND_WEBHOOK_SECRET",
         "TURNSTILE_SECRET_KEY",
         "SANITY_STUDIO_*",
         "SANITY_AUTH_TOKEN"


### PR DESCRIPTION
## Summary
- Replace the immediate "we received it" confirmation with a webhook-driven flow: senders only hear back once Resend reports a terminal event. `email.delivered` triggers a delivery-confirmation email; `email.bounced` / `email.complained` / `email.failed` / `email.canceled` trigger a failure email pointing at `enquiries@sudburyrowingclub.org.uk` as a fallback. Non-terminal events (including `opened` and `clicked`) are ignored.
- In-flight officer emails are tracked in Vercel KV (`contact:inflight:{messageId}` → `{fromEmail, fromName, toName, toRole}`, 72h TTL), and the entry is deleted once a terminal notification has been sent.
- Neither sender-facing template exposes the officer's email address; the failure template directs the sender to `enquiries@…` instead.

## Test plan
- [x] Unit tests for dispatch matrix and privacy guarantees (17 tests at `apps/web/app/api/webhooks/resend/route.test.ts`)
- [x] `pnpm --filter @sudburyrc/web email-dev` — visually verify `contact-form-delivered` and `contact-form-failed` templates
- [x] Set `RESEND_WEBHOOK_SECRET` and `KV_*` env vars on the Vercel preview
- [x] In the Resend dashboard, add `https://<preview>.vercel.app/api/webhooks/resend` as a webhook endpoint, subscribing to `email.sent`, `email.delivered`, `email.bounced`, `email.complained`, `email.failed`, `email.delivery_delayed`
- [x] Temporarily point a Sanity officer record at `delivered@resend.dev`, submit the contact form, confirm the delivery-confirmation email lands
- [x] Repeat with `bounced@resend.dev` — confirm the failure email lands with `enquiries@…` fallback
- [x] Repeat with `complained@resend.dev` — confirm same failure path
- [x] Revert Sanity officer record